### PR TITLE
Add `options` parameter to `createServer`, with `onError` to add context to certain errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ in order to prevent execution of further code.
 
 ```tsx
 app.get("/", async (req, res) => {
-  function onError(error: unknown): void {
+  function onError(error: Error): void {
     // Instrument the error here, such as to add context:
     error.userID = req.userID
     // Or send it to a monitoring service:
@@ -439,6 +439,7 @@ app.get("/", async (req, res) => {
   }
 
   const appHTML = Purview.render(<App />, req, { onError })
+  // ...
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -429,13 +429,11 @@ in order to prevent execution of further code.
 
 ```tsx
 app.get("/", async (req, res) => {
-  function onError(error: Error): void {
+  function onError(error: unknown): void {
     // Instrument the error here, such as to add context:
     error.userID = req.userID
     // Or send it to a monitoring service:
     logError(error)
-    // Or throw a custom error class:
-    throw new PurviewCustomError(error)
   }
 
   const appHTML = Purview.render(<App />, req, { onError })

--- a/README.md
+++ b/README.md
@@ -409,56 +409,36 @@ Components](https://github.com/styled-components/styled-components) and
 Purview components do not run in the browser.
 
 ## Error handling
-Uncaught errors within Purview will bubble up as
-[`uncaughtException`][uncaught-exception] or
-[`unhandledRejection`][unhandled-rejection] events. These can be caught and
-handled by registering event listeners on `process`.
+Normally, when an error occurs in the context of a Purview component, it will 
+appear as top-level [`uncaughtException`][uncaught-exception] or
+[`unhandledRejection`][unhandled-rejection] events. Purview provides the option
+to observe or modify these errors with a custom error handler before they
+appear within these top-level events.
 
-Additionally, certain classes of errors can be instrumented in Purview prior to
-going to these top-level events:
+In order to add a custom error handler, pass an `onError` function as an option
+to `Purview.render()`. When provided, the handler is invoked for these classes
+of Purview errors:
 
 - Errors within event callbacks.
 - Errors in the component render path.
 - Errors when setting initial component state, after WebSocket connection is
 established.
 
-Register an instrumentation function by passing it in as an option parameter to
-`Purview.render()`:
+If your handler does not itself throw an error, Purview will re-throw the error
+in order to prevent execution of further code.
 
 ```tsx
-const app = express()
-
 app.get("/", async (req, res) => {
   function onError(error: unknown): void {
-    // Instrument your error here, such as sending it to a monitoring service
-    // or adding context from the request.
+    // Instrument the error here, such as to add context:
+    error.userID = req.userID
+    // Or send it to a monitoring service:
+    logError(error)
+    // Or throw a custom error class:
+    throw new PurviewCustomError(error)
   }
 
-  // Pass onError inside Purview.render's third argument.
   const appHTML = Purview.render(<App />, req, { onError })
-  const styleHTML = await Purview.renderCSS(req)
-  res.send(`
-    <html>
-      <head>
-        ${styleHTML}
-      </head>
-      <body>
-        ${appHTML}
-        <script src="/script.js"></script>
-      </body>
-    </html>
-  `)
-})
-app.get("/script.js", (_, res) => res.sendFile(Purview.scriptPath))
-
-// Even instrumented errors will bubble up, because the error handler does not
-// prevent the error from occurring.
-process.on("uncaughtException", (error) => {
-  // Handle Purview errors here.
-})
-
-process.on("unhandledRejection", (reason, promise) => {
-  // Handle Purview errors here.
 })
 ```
 

--- a/src/component.ts
+++ b/src/component.ts
@@ -134,8 +134,12 @@ abstract class Component<P, S> {
     }
 
     this._lockedPromise = (async () => {
-      const result = await callback()
-      this._lockedPromise = null
+      let result
+      try {
+        result = await callback()
+      } finally {
+        this._lockedPromise = null
+      }
       return result
     })()
 

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -23,6 +23,7 @@ import {
   PNode,
   PNodeRegular,
   UpdateMessage,
+  PurviewEvent,
 } from "./types/ws"
 import {
   makeInputEventValidator,
@@ -150,7 +151,8 @@ const cachedEventIDs: WeakMap<EventCallback, string> = new WeakMap()
 //
 // We keep track of errors that have already been passed to the onError handler
 // below such that the same error is never passed twice. For example, an error
-// that occurs in a component.render() call caused by an event callback could
+// that occurs in a component.render() call caused by an event callback (e.g.
+// an awaited component.setState() that subsequently triggers a render) could
 // otherwise be passed to onError more than once.
 const seenErrors: WeakSet<Error> = new WeakSet()
 
@@ -735,7 +737,7 @@ async function makeRegularElem(
     if (root.connected) {
       parent._newEventHandlers[eventID] = {
         eventName,
-        callback: async event => {
+        async callback(event?: PurviewEvent): Promise<void> {
           try {
             await callback(event)
           } catch (error) {

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -41,6 +41,10 @@ import {
   getAtomicProperties,
 } from "./css"
 
+export interface RenderOptions {
+  onError?: ErrorHandler
+}
+
 export interface WebSocketOptions {
   origin: string | null
 }
@@ -140,6 +144,7 @@ const INPUT_TYPE_VALIDATOR: Record<
 }
 
 const cachedEventIDs: WeakMap<EventCallback, string> = new WeakMap()
+const seenErrors: WeakSet<Error> = new WeakSet()
 
 const WEBSOCKET_BAD_STATUS_FORMAT =
   "Purview: request to your server (GET %s) returned status code %d, so we couldn't start the WebSocket connection."
@@ -493,20 +498,10 @@ async function handleMessage(
       if (handler.validator) {
         const decoded = handler.validator.decode(message.event)
         if (decoded.isRight()) {
-          try {
-            await handler.callback(decoded.value)
-          } catch (error) {
-            root.onError?.(error)
-            throw error
-          }
+          await handler.callback(decoded.value)
         }
       } else {
-        try {
-          await handler.callback()
-        } catch (error) {
-          root.onError?.(error)
-          throw error
-        }
+        await handler.callback()
       }
       break
     }
@@ -538,8 +533,10 @@ function sendMessage(ws: WebSocket, message: ServerMessage): void {
 export async function render(
   jsx: JSX.Element,
   req: http.IncomingMessage,
-  onError: ErrorHandler | null = null,
+  options: RenderOptions = {},
 ): Promise<string> {
+  const onError = options.onError ?? null
+
   if (!isComponentElem(jsx)) {
     throw new Error("Root element must be a Purview.Component")
   }
@@ -553,64 +550,69 @@ export async function render(
   }
 
   const stateTree = idStateTree && idStateTree.stateTree
-  try {
-    return await withComponent(jsx, stateTree, async component => {
-      if (!component) {
-        throw new Error("Expected non-null component")
-      }
+  return await withComponent(jsx, stateTree, async component => {
+    if (!component) {
+      throw new Error("Expected non-null component")
+    }
 
-      let root: ConnectedRoot | DisconnectedRoot
-      if (purviewState) {
-        // This is the request from the websocket connection.
-        component._id = idStateTree!.id
-        root = {
-          connected: true,
-          component,
-          wsState: purviewState.wsState,
-          eventNames: new Set(),
-          aliases: {},
-          allComponentsMap: { [component._id]: component },
-          onError,
-        }
-        purviewState.roots = purviewState.roots || []
-        purviewState.roots.push(root)
-      } else {
-        // This is the initial render.
-        req.purviewCSSState = req.purviewCSSState ?? {
-          id: nanoid(),
-          atomicCSS: {},
-          cssRules: [],
-          nextRuleIndex: 0,
-        }
-        if (req.purviewCSSRendered) {
-          throw new Error(RENDER_CSS_ORDERING_ERROR)
-        }
-        root = {
-          connected: false,
-          cssState: req.purviewCSSState,
-          onError,
+    let onUnseenError: ErrorHandler | null = null
+    if (onError) {
+      onUnseenError = error => {
+        if (!seenErrors.has(error)) {
+          seenErrors.add(error)
+          onError(error)
         }
       }
+    }
 
-      const pNode = await renderComponent(component, component._id, root)
-      if (!pNode) {
-        throw new Error("Expected non-null node")
+    let root: ConnectedRoot | DisconnectedRoot
+    if (purviewState) {
+      // This is the request from the websocket connection.
+      component._id = idStateTree!.id
+      root = {
+        connected: true,
+        component,
+        wsState: purviewState.wsState,
+        eventNames: new Set(),
+        aliases: {},
+        allComponentsMap: { [component._id]: component },
+        onError: onUnseenError,
       }
+      purviewState.roots = purviewState.roots || []
+      purviewState.roots.push(root)
+    } else {
+      // This is the initial render.
+      req.purviewCSSState = req.purviewCSSState ?? {
+        id: nanoid(),
+        atomicCSS: {},
+        cssRules: [],
+        nextRuleIndex: 0,
+      }
+      if (req.purviewCSSRendered) {
+        throw new Error(RENDER_CSS_ORDERING_ERROR)
+      }
+      root = {
+        connected: false,
+        cssState: req.purviewCSSState,
+        onError: onUnseenError,
+      }
+    }
 
-      if (purviewState) {
-        return ""
-      } else {
-        await reloadOptions.saveStateTree(
-          component._id,
-          makeStateTree(component, false),
-        )
-        return toHTML(pNode)
-      }
-    })
-  } catch (error) {
-    onError?.(error)
-    throw error
-  }
+    const pNode = await renderComponent(component, component._id, root)
+    if (!pNode) {
+      throw new Error("Expected non-null node")
+    }
+
+    if (purviewState) {
+      return ""
+    } else {
+      await reloadOptions.saveStateTree(
+        component._id,
+        makeStateTree(component, false),
+      )
+      return toHTML(pNode)
+    }
+  })
 }
 
 export async function renderCSS(req: http.IncomingMessage): Promise<string> {
@@ -725,7 +727,16 @@ async function makeRegularElem(
     if (root.connected) {
       parent._newEventHandlers[eventID] = {
         eventName,
-        callback,
+        callback: async event => {
+          try {
+            return await callback(event)
+          } catch (error) {
+            root.onError?.(error)
+            if (process.env.NODE_ENV !== "test") {
+              throw error
+            }
+          }
+        },
       }
       root.eventNames.add(eventName)
 
@@ -858,6 +869,7 @@ async function withComponent<T>(
   jsx: JSX.ComponentElement,
   existing: Component<any, any> | StateTree | null | undefined,
   callback: (component: Component<any, any> | null) => T,
+  root?: ConnectedRoot | DisconnectedRoot,
 ): Promise<T> {
   const { nodeName, attributes, children } = jsx
   const props = Object.assign({ children }, attributes)
@@ -874,15 +886,24 @@ async function withComponent<T>(
       return callback(null)
     }
 
+    let result
     if (existing instanceof Component) {
       component._setProps(props)
       component._applyChangesetsLocked()
     } else if (existing) {
       component._childMap = existing.childMap
-      await component._initState(existing.state, existing.reload)
+      result = component._initState(existing.state, existing.reload)
     } else {
-      await component._initState()
+      result = component._initState()
     }
+
+    try {
+      await result
+    } catch (error) {
+      root?.onError?.(error)
+      throw error
+    }
+
     return callback(component)
   })
 }
@@ -895,8 +916,16 @@ async function renderComponent(
   component._newChildMap = {}
   component._newEventHandlers = {}
 
+  let jsx
+  try {
+    jsx = component.render()
+  } catch (error) {
+    root.onError?.(error)
+    throw error
+  }
+
   const pNode = (await makeElem(
-    component.render(),
+    jsx,
     component,
     rootID,
     root,

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -117,7 +117,7 @@ export interface EventHandler {
   validator?: t.Type<any, any, any>
 }
 
-export type ErrorHandler = (error: Error) => void
+export type ErrorHandler = (error: unknown) => void
 
 interface IDStateTree {
   id: string
@@ -154,7 +154,7 @@ const cachedEventIDs: WeakMap<EventCallback, string> = new WeakMap()
 // that occurs in a component.render() call caused by an event callback (e.g.
 // an awaited component.setState() that subsequently triggers a render) could
 // otherwise be passed to onError more than once.
-const seenErrors: WeakSet<Error> = new WeakSet()
+const seenErrors = new WeakSet()
 
 const WEBSOCKET_BAD_STATUS_FORMAT =
   "Purview: request to your server (GET %s) returned status code %d, so we couldn't start the WebSocket connection."
@@ -568,6 +568,11 @@ export async function render(
     let onUnseenError: ErrorHandler | null = null
     if (onError) {
       onUnseenError = error => {
+        if (typeof error !== "object" || error === null) {
+          onError(error)
+          return
+        }
+
         if (!seenErrors.has(error)) {
           seenErrors.add(error)
           onError(error)

--- a/src/types/ws.ts
+++ b/src/types/ws.ts
@@ -39,7 +39,7 @@ export type PurviewEvent =
   | ChangeEvent<any>
   | SubmitEvent
   | KeyEvent
-export type EventCallback = (event?: PurviewEvent) => void
+export type EventCallback = (event?: PurviewEvent) => void | Promise<void>
 
 export interface ConnectMessage {
   type: "connect"

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -2063,8 +2063,6 @@ test("onError, eventCallback", async () => {
   const error = new Error("eventCallback error")
   class Foo extends TestComponent<{}, {}> {
     async onClick(): Promise<void> {
-      // Await a promise in order to execute in a microtask.
-      await new Promise(resolve => setTimeout(resolve, 1))
       throw error
     }
 
@@ -2117,8 +2115,6 @@ test("onError, eventCallback and getInitialState", async () => {
     }
 
     async getInitialState(): Promise<{}> {
-      // Await a promise in order to execute in a microtask.
-      await new Promise(resolve => setTimeout(resolve, 1))
       throw error
     }
 

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -2018,22 +2018,23 @@ test("unique component name with getUniqueName", async () => {
 })
 
 test("onError, top-level render", async () => {
-  const errorMessage = "render error"
+  const error = new Error("top-level render error")
   class Foo extends TestComponent<{}, {}> {
     render(): JSX.Element {
-      throw new Error(errorMessage)
+      throw error
     }
   }
 
   const onError = jest.fn()
   await expect(Purview.render(<Foo />, {} as any, { onError })).rejects.toThrow(
-    errorMessage,
+    error,
   )
   expect(onError).toBeCalledTimes(1)
+  expect(onError).toBeCalledWith(error)
 })
 
 test("onError, child render", async () => {
-  const errorMessage = "render error"
+  const error = new Error("child render error")
   class Foo extends TestComponent<{}, {}> {
     render(): JSX.Element {
       return <Bar />
@@ -2046,22 +2047,25 @@ test("onError, child render", async () => {
     }
 
     render(): JSX.Element {
-      throw new Error(errorMessage)
+      throw error
     }
   }
 
   const onError = jest.fn()
   await expect(Purview.render(<Foo />, {} as any, { onError })).rejects.toThrow(
-    errorMessage,
+    error,
   )
   expect(onError).toBeCalledTimes(1)
+  expect(onError).toBeCalledWith(error)
 })
 
 test("onError, eventCallback", async () => {
-  const errorMessage = "eventCallback error"
+  const error = new Error("eventCallback error")
   class Foo extends TestComponent<{}, {}> {
     async onClick(): Promise<void> {
-      throw new Error(errorMessage)
+      // Await a promise in order to execute in a microtask.
+      await new Promise(resolve => setTimeout(resolve, 1))
+      throw error
     }
 
     render(): JSX.Element {
@@ -2083,13 +2087,14 @@ test("onError, eventCallback", async () => {
       // Wait for handlers to be called.
       await new Promise(resolve => setTimeout(resolve, 25))
       expect(onError).toBeCalledTimes(1)
+      expect(onError).toBeCalledWith(error)
     },
     { onError },
   )
 })
 
 test("onError, eventCallback and getInitialState", async () => {
-  const errorMessage = "eventCallback and getInitialState error"
+  const error = new Error("eventCallback and getInitialState error")
   class Foo extends TestComponent<{}, { on: boolean }> {
     state = { on: false }
 
@@ -2112,7 +2117,9 @@ test("onError, eventCallback and getInitialState", async () => {
     }
 
     async getInitialState(): Promise<{}> {
-      throw new Error(errorMessage)
+      // Await a promise in order to execute in a microtask.
+      await new Promise(resolve => setTimeout(resolve, 1))
+      throw error
     }
 
     render(): JSX.Element {
@@ -2134,13 +2141,14 @@ test("onError, eventCallback and getInitialState", async () => {
       // Wait for handlers to be called.
       await new Promise(resolve => setTimeout(resolve, 25))
       expect(onError).toBeCalledTimes(1)
+      expect(onError).toBeCalledWith(error)
     },
     { onError },
   )
 })
 
 test("onError, eventCallback and render", async () => {
-  const errorMessage = "eventCallback and render error"
+  const error = new Error("eventCallback and render error")
   class Foo extends TestComponent<{}, { on: boolean }> {
     state = { on: false }
 
@@ -2163,7 +2171,7 @@ test("onError, eventCallback and render", async () => {
     }
 
     render(): JSX.Element {
-      throw new Error(errorMessage)
+      throw error
     }
   }
 
@@ -2181,6 +2189,7 @@ test("onError, eventCallback and render", async () => {
       // Wait for handlers to be called.
       await new Promise(resolve => setTimeout(resolve, 25))
       expect(onError).toBeCalledTimes(1)
+      expect(onError).toBeCalledWith(error)
     },
     { onError },
   )


### PR DESCRIPTION
## Background
Errors generated by Purview bubble to the top-level `uncaughtException` and `unhandledRejection` events. In a large application, it can be difficult to track the context in which these errors occur, because error objects do not provide any information surrounding the error beyond the call stack.

Therefore, I would like to propose a new parameter that allows us to add context to the most common errors before it bubbles to these top-level listeners.

## Changes made in this PR
### Making `EventCallback` potentially asynchronous
Previously, `EventCallback` is typed as:
```ts
export type EventCallback = (event?: PurviewEvent) => void
```

This usage allows both synchronous and asynchronous functions to conform to this type, but it has the side effect that the `handler.callback()` calls are never awaited, even in the case of asynchronous functions:
https://github.com/karthikv/purview/blob/d2b376e8999898cec0e6556c0773eb6025fcda8d/src/purview.ts#L489-L496

As a consequence, any promise rejections are thrown off the stack and are uncatchable. For the purposes of this PR, I make the change the return type as `void | Promise<void>` instead and to `await` the handler callbacks.

### `options` function parameter
In this PR, I propose adding an `options: RenderOptions = {}` parameter to `createServer`. Currently, `RenderOptions` is defined as having one key only:
```ts
interface RenderOptions {
  onError?: ErrorHandler // see details below
}
```

We propose an options object to minimize the surface area of changes in the future should more options be added later. We also default the options object to an empty object `{}` so that current users of Purview will not be required to change their code to add the new option.

### `onError` option
The `ErrorHandler` type is defined as:
```ts
type ErrorHandler = (error: Error) => void
```
The purpose is to add context to the error from the lexical scope of the `createServer` caller, such that when it is re-thrown and appears in the top-level, it contains the added information.
```ts
try {
  potentiallyError()
} catch (error) {
  // We run the supplied function here, which may or may not throw an error depending on user.
  onError?.(error)
  // Re-throw afterwards, since we do not want to continue execution.
  throw error
}
```

It is important that since this function may contain side effects, for any given error path it is only called once. In order to guarantee that each `ErrorHandler` is only called once for a given error, I created a top-level `seenErrors: WeakSet<Error>` and only call `onError` if it is not in the set. I wrap the `onError` before it is 
stored in `ConnectedRoot` and `DisconnectedRoot` such that:
```ts
onUnseenError = error => {
  if (!seenErrors.has(error)) {
    seenErrors.add(error)
    onError(error)
  }
}

root.onError = onUnseenError
```
Because the handler is available in the root, it is available to all functions where `root` is available.

This pattern has been added to these locations:
- Wrapping `component._initState()` in `withComponent`. Note that I added an additional optional `root?` parameter because this component is called on initial render and subsequent updates, but `root` is not available on initial render.
- Around `component.render()` call in `renderComponent`.

### Caught errors
- Errors on event callbacks (e.g. errors that happen in response to a button click) are caught.
- Errors in the component render path are caught.
- Errors in `getInitialState()` or direct state assignment are called, except for initial render path before WS is established.

### Uncaught errors
- Lifecycle events are not caught.

### Other details
- In the handler for event callbacks, I only re-throw the error if `NODE_ENV !== "test"`. Unfortunately, tests for `EventCallback` fail without this behavior because of an unhandled rejection.
- In the `component._lock()` function, I changed the creation of a new `_lockedPromise` to always nullify even if `callback()` fails. I found that if an error on the `_triggerMount()` call occurs, the rejected promise remains in `_lockedPromise` because the callback did not successfully finish. When the component is called `_triggerUnmount()` during test teardown, the [`await this._lockedPromise` call](https://github.com/karthikv/purview/blob/0af84aea2fee68b25af60c09f1507b7253fb22b9/src/component.ts#L131-L134) would immediately fail, causing the test to fail due to unhandled rejection.

## Tests modifications
I have added automated tests for the error cases above:
- 2 render tests, one for root and one for child
- 3 eventCallback tests, one simple, and two in conjunction with `getInitialState()` and `render()` (ensures that the error handler is only called once even when the instrumented paths are in the same stack)