### PR TITLE
Make sure WebSocket state is cleaned up when "close" and "connect" events race

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,7 @@ environment:
 cache: [node_modules]
 install:
   - ps: Install-Product node $env:nodejs_version
-  # Using `npm i` respects the package-lock.json file. Otherwise, the
-  # dependencies within package.json will be updated automatically. The use of
-  # `npm i` requires the use of node v16+.
-  - npm i
+  - npm install
 test_script:
   - bin\lint
   - bin\test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,9 @@ environment:
 cache: [node_modules]
 install:
   - ps: Install-Product node $env:nodejs_version
+  # Using `npm i` respects the package-lock.json file. Otherwise, the
+  # dependencies within package.json will be updated automatically. The use of
+  # `npm i` requires the use of node v16+.
   - npm i
 test_script:
   - bin\lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 environment:
   matrix:
-    - nodejs_version: "10"
+    - nodejs_version: "16"
 cache: [node_modules]
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install
+  - npm i
 test_script:
   - bin\lint
   - bin\test

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "purview",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^6.0.1",

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -470,9 +470,9 @@ async function handleMessage(
       // fires just after the "connect" event (e.g., on page refresh), and the
       // "close" event will see that the `wsState.roots` is an empty array due
       // to the "connect" event still being in progress. This would result in an
-      // incomplete clean up of the previous connection's state. Hence, we check
+      // incomplete cleanup of the previous connection's state. Hence, we check
       // the `closing` flag and clean up any existing state that the "closing"
-      // event could not cleanup if needed.
+      // event could not clean up if needed.
       if (wsState.closing) {
         await cleanUpWebSocketState(wsState)
         wsState.closing = false

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -330,7 +330,7 @@ export function handleWebSocket(
         return
       }
 
-      await saveState(wsState)
+      await saveRootsState(wsState)
       wsState.closing = false
     })
   })
@@ -459,7 +459,7 @@ async function handleMessage(
 
       wsState.connected = true
       if (wsState.closing) {
-        await saveState(wsState)
+        await saveRootsState(wsState)
         wsState.closing = false
       }
 
@@ -1092,7 +1092,7 @@ function unalias(id: string, root: ConnectedRoot): string {
   return id
 }
 
-async function saveState(wsState: WebSocketState): Promise<void> {
+async function saveRootsState(wsState: WebSocketState): Promise<void> {
   const promises = wsState.roots.map(async root => {
     const stateTree = makeStateTree(root.component, true)
     await reloadOptions.saveStateTree(root.component._id, stateTree)

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -65,8 +65,7 @@ interface WebSocketStateNoCSS extends BaseWebSocketState {
 interface BaseWebSocketState {
   ws: WebSocket
   roots: ConnectedRoot[]
-  connecting: boolean
-  connected: boolean
+  connectionState: null | "connecting" | "connected"
   mounted: boolean
   closing: boolean
   seenEventNames: Set<string>
@@ -303,8 +302,7 @@ export function handleWebSocket(
     const wsStateBase: WebSocketState = {
       ws,
       roots: [] as ConnectedRoot[],
-      connecting: false,
-      connected: false,
+      connectionState: null,
       mounted: false,
       closing: false,
       seenEventNames: new Set(),
@@ -326,11 +324,19 @@ export function handleWebSocket(
 
     ws.on("close", async () => {
       wsState.closing = true
-      if (!wsState.connected) {
+      // We check if `connectionState` is set to "connected" because it could be
+      // the case that the "close" event fires just after the "connect" event
+      // (e.g., on page refresh), and the "close" event will see that the
+      // `wsState.roots` is an empty array due to the "connect" still being in
+      // progress. This would result in an incomplete cleanup of the previous
+      // connection's state. Hence, we return early, set the `closing` flag, and
+      // let the "connect" event clean up the existing state by signaling with
+      // `closing`.
+      if (wsState.connectionState !== "connected") {
         return
       }
 
-      await saveRootsState(wsState)
+      await cleanupExistingState(wsState)
       wsState.closing = false
     })
   })
@@ -370,10 +376,10 @@ async function handleMessage(
 ): Promise<void> {
   switch (message.type) {
     case "connect": {
-      if (wsState.connecting) {
+      if (wsState.connectionState !== null) {
         break
       }
-      wsState.connecting = true
+      wsState.connectionState = "connecting"
 
       const cssStateID = message.cssStateID
       if (cssStateID) {
@@ -457,9 +463,16 @@ async function handleMessage(
       }
       await Promise.all(deletePromises)
 
-      wsState.connected = true
+      wsState.connectionState = "connected"
+      // We check if `closing` is set because it could be the case that the
+      // "close" event fires just after the "connect" event (e.g., on page
+      // refresh), and the "close" event will see that the `wsState.roots` is an
+      // empty array due to the "connect" still being in progress. This would
+      // result in an incomplete cleanup of the previous connection's state.
+      // Hence, we check the `closing` flag and cleanup any existing state that
+      // the "closing" event could not cleanup if needed.
       if (wsState.closing) {
-        await saveRootsState(wsState)
+        await cleanupExistingState(wsState)
         wsState.closing = false
       }
 
@@ -1092,7 +1105,7 @@ function unalias(id: string, root: ConnectedRoot): string {
   return id
 }
 
-async function saveRootsState(wsState: WebSocketState): Promise<void> {
+async function cleanupExistingState(wsState: WebSocketState): Promise<void> {
   const promises = wsState.roots.map(async root => {
     const stateTree = makeStateTree(root.component, true)
     await reloadOptions.saveStateTree(root.component._id, stateTree)

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -1743,9 +1743,8 @@ test("reconnect", async () => {
     conn.ws.close()
 
     // Wait for state to be saved and unmount to occur.
-    await new Promise(resolve => setTimeout(resolve, 25))
+    // await new Promise(resolve => setTimeout(resolve, 25))
     expect(mountCount).toBe(1)
-    expect(unmountCount).toBe(1)
 
     const origin = `http://localhost:${conn.port}`
     const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
@@ -1756,6 +1755,11 @@ test("reconnect", async () => {
       rootIDs: [conn.rootID],
     }
     ws.send(JSON.stringify(connect))
+
+    // Either the "close" event will execute the unmounting, or on reconnect the
+    // unmounting will occur because the `closing` flag is set during "connect".
+    // So there's no need to busy wait for an unmount anymore.
+    expect(unmountCount).toBe(1)
 
     await new Promise(resolve => {
       ws.addEventListener("message", messageEvent => {
@@ -1812,8 +1816,6 @@ test("reconnect new child component mount cycle", async () => {
   await renderAndConnect(<Foo />, async conn => {
     conn.ws.close()
 
-    // Wait for state to be saved and unmount to occur.
-    await new Promise(resolve => setTimeout(resolve, 25))
     const origin = `http://localhost:${conn.port}`
     const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
     await new Promise(resolve => ws.addEventListener("open", resolve))
@@ -1862,8 +1864,6 @@ test("reconnect getInitialState()", async () => {
     expect(count).toBe(1)
     conn.ws.close()
 
-    // Wait for state to be saved and unmount to occur.
-    await new Promise(resolve => setTimeout(resolve, 25))
     const origin = `http://localhost:${conn.port}`
     const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
     await new Promise(resolve => ws.addEventListener("open", resolve))

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -1742,7 +1742,10 @@ test("reconnect", async () => {
     await conn.messages.next()
     conn.ws.close()
 
+    // Wait for state to be saved and unmount to occur.
+    await new Promise(resolve => setTimeout(resolve, 25))
     expect(mountCount).toBe(1)
+    expect(unmountCount).toBe(1)
 
     const origin = `http://localhost:${conn.port}`
     const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
@@ -1753,11 +1756,6 @@ test("reconnect", async () => {
       rootIDs: [conn.rootID],
     }
     ws.send(JSON.stringify(connect))
-
-    // Either the "close" event will execute the unmounting, or on reconnect the
-    // unmounting will occur because the `closing` flag is set during "connect".
-    // So there's no need to busy wait for an unmount anymore.
-    expect(unmountCount).toBe(1)
 
     await new Promise(resolve => {
       ws.addEventListener("message", messageEvent => {
@@ -1862,6 +1860,8 @@ test("reconnect getInitialState()", async () => {
     expect(count).toBe(1)
     conn.ws.close()
 
+    // Wait for state to be saved and unmount to occur.
+    await new Promise(resolve => setTimeout(resolve, 25))
     const origin = `http://localhost:${conn.port}`
     const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
     await new Promise(resolve => ws.addEventListener("open", resolve))

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -17,6 +17,7 @@ import Purview, {
   css,
   RENDER_CSS_ORDERING_ERROR,
   styledTag,
+  reloadOptions,
 } from "../src/purview"
 import { parseHTML, concretize, STYLE_TAG_ID } from "../src/helpers"
 import {
@@ -1904,6 +1905,86 @@ test("reconnect early", async () => {
     }
     ws.send(JSON.stringify(connect))
     await new Promise(resolve => ws.addEventListener("close", resolve))
+  })
+})
+
+test("simulate a page refresh", async () => {
+  let instance: Foo
+  let mountCount = 0
+  let unmountCount = 0
+
+  class Foo extends TestComponent<{}, { text: string }> {
+    state = { text: "hi" }
+
+    constructor(props: {}) {
+      super(props)
+      instance = this
+    }
+
+    componentDidMount(): void {
+      mountCount++
+    }
+
+    componentWillUnmount(): void {
+      unmountCount++
+    }
+
+    render(): JSX.Element {
+      return <p>{this.state.text}</p>
+    }
+  }
+
+  await renderAndConnect(<Foo />, async conn => {
+    expect(mountCount).toBe(1)
+    expect(unmountCount).toBe(0)
+
+    void instance.setState({ text: "hello" })
+    await conn.messages.next()
+    conn.ws.close()
+
+    // Wait for state to be saved and unmount to occur. And wait for the state
+    // to be saved into the db to help simulate the page refresh scenario.
+    await new Promise(resolve => setTimeout(resolve, 25))
+    expect(mountCount).toBe(1)
+    expect(unmountCount).toBe(1)
+
+    const origin = `http://localhost:${conn.port}`
+    const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
+    await new Promise(resolve => ws.addEventListener("open", resolve))
+
+    const originalDeleteStateTree = reloadOptions.deleteStateTree.bind(
+      reloadOptions,
+    )
+    reloadOptions.deleteStateTree = jest.fn(async rootID => {
+      // Create an artificial delay when deleting state trees so that "connect"
+      // takes a while to let the "close" event execute before "connect"
+      // finishes.
+      await new Promise(resolve => setTimeout(resolve, 200))
+      await originalDeleteStateTree(rootID)
+    })
+    const connect: ClientMessage = {
+      type: "connect",
+      rootIDs: [conn.rootID],
+    }
+    ws.send(JSON.stringify(connect))
+    await new Promise(resolve => {
+      ws.addEventListener("message", messageEvent => {
+        // Create the race condition for having "close" execute while "connect"
+        // is executing.
+        ws.close()
+        const message: ServerMessage = JSON.parse(messageEvent.data.toString())
+        expect(message.type).toBe("update")
+        resolve()
+      })
+    })
+
+    expect(mountCount).toBe(2)
+    expect(unmountCount).toBe(1)
+
+    // Wait for state to be saved and unmount to occur in "connect."
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(mountCount).toBe(2)
+    expect(unmountCount).toBe(2)
   })
 })
 

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -1742,8 +1742,6 @@ test("reconnect", async () => {
     await conn.messages.next()
     conn.ws.close()
 
-    // Wait for state to be saved and unmount to occur.
-    // await new Promise(resolve => setTimeout(resolve, 25))
     expect(mountCount).toBe(1)
 
     const origin = `http://localhost:${conn.port}`

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -1912,9 +1912,7 @@ test("cleanup happens when 'close' and 'connect' race", async () => {
   let mountCount = 0
   let unmountCount = 0
 
-  class Foo extends TestComponent<{}, { text: string }> {
-    state = { text: "hi" }
-
+  class Foo extends TestComponent<{}, {}> {
     constructor(props: {}) {
       super(props)
     }
@@ -1928,7 +1926,7 @@ test("cleanup happens when 'close' and 'connect' race", async () => {
     }
 
     render(): JSX.Element {
-      return <p>{this.state.text}</p>
+      return <div />
     }
   }
 
@@ -1937,8 +1935,7 @@ test("cleanup happens when 'close' and 'connect' race", async () => {
     expect(unmountCount).toBe(0)
     conn.ws.close()
 
-    // Wait for state to be saved and unmount to occur. And wait for the state
-    // to be saved into the db to help simulate the page refresh scenario.
+    // Wait for state to be saved and unmount to occur.
     await new Promise(resolve => setTimeout(resolve, 25))
     expect(mountCount).toBe(1)
     expect(unmountCount).toBe(1)
@@ -1948,14 +1945,13 @@ test("cleanup happens when 'close' and 'connect' race", async () => {
     await new Promise(resolve => ws.addEventListener("open", resolve))
 
     // To avoid infinite recursion, we only mock the first call to
-    // `getStateTree`. To allow jest to cleanup the mock implementation, we use
+    // `getStateTree`. To allow jest to clean up the mock implementation, we use
     // `spyOn` and call `spy.mockRestore()` once test execution has completed.
     // This prevent subsequnt tests from using the mock implementation.
     const spy = jest.spyOn(reloadOptions, "getStateTree")
     spy.mockImplementationOnce(async rootID => {
-      // Create an artificial delay when deleting state trees so that "connect"
-      // takes a while to let the "close" event execute before "connect"
-      // finishes.
+      // Create an artificial delay when fetching state trees so that the
+      // "close" event executes before the "connect" event finishes.
       await new Promise(resolve => setTimeout(resolve, 200))
       return await reloadOptions.getStateTree(rootID)
     })
@@ -1966,7 +1962,7 @@ test("cleanup happens when 'close' and 'connect' race", async () => {
     ws.send(JSON.stringify(connect))
     ws.close()
 
-    // Wait for state to be saved and unmount to occur in "connect."
+    // Wait for state to be saved and unmount to occur.
     await new Promise(resolve => setTimeout(resolve, 250))
     expect(mountCount).toBe(2)
     expect(unmountCount).toBe(2)

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -1908,86 +1908,6 @@ test("reconnect early", async () => {
   })
 })
 
-test("simulate a page refresh", async () => {
-  let instance: Foo
-  let mountCount = 0
-  let unmountCount = 0
-
-  class Foo extends TestComponent<{}, { text: string }> {
-    state = { text: "hi" }
-
-    constructor(props: {}) {
-      super(props)
-      instance = this
-    }
-
-    componentDidMount(): void {
-      mountCount++
-    }
-
-    componentWillUnmount(): void {
-      unmountCount++
-    }
-
-    render(): JSX.Element {
-      return <p>{this.state.text}</p>
-    }
-  }
-
-  await renderAndConnect(<Foo />, async conn => {
-    expect(mountCount).toBe(1)
-    expect(unmountCount).toBe(0)
-
-    void instance.setState({ text: "hello" })
-    await conn.messages.next()
-    conn.ws.close()
-
-    // Wait for state to be saved and unmount to occur. And wait for the state
-    // to be saved into the db to help simulate the page refresh scenario.
-    await new Promise(resolve => setTimeout(resolve, 25))
-    expect(mountCount).toBe(1)
-    expect(unmountCount).toBe(1)
-
-    const origin = `http://localhost:${conn.port}`
-    const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
-    await new Promise(resolve => ws.addEventListener("open", resolve))
-
-    const originalDeleteStateTree = reloadOptions.deleteStateTree.bind(
-      reloadOptions,
-    )
-    reloadOptions.deleteStateTree = jest.fn(async rootID => {
-      // Create an artificial delay when deleting state trees so that "connect"
-      // takes a while to let the "close" event execute before "connect"
-      // finishes.
-      await new Promise(resolve => setTimeout(resolve, 200))
-      await originalDeleteStateTree(rootID)
-    })
-    const connect: ClientMessage = {
-      type: "connect",
-      rootIDs: [conn.rootID],
-    }
-    ws.send(JSON.stringify(connect))
-    await new Promise(resolve => {
-      ws.addEventListener("message", messageEvent => {
-        // Create the race condition for having "close" execute while "connect"
-        // is executing.
-        ws.close()
-        const message: ServerMessage = JSON.parse(messageEvent.data.toString())
-        expect(message.type).toBe("update")
-        resolve()
-      })
-    })
-
-    expect(mountCount).toBe(2)
-    expect(unmountCount).toBe(1)
-
-    // Wait for state to be saved and unmount to occur in "connect."
-    await new Promise(resolve => setTimeout(resolve, 200))
-    expect(mountCount).toBe(2)
-    expect(unmountCount).toBe(2)
-  })
-})
-
 test("setState() after unmount", async () => {
   let instance: Foo = null as any
   class Foo extends TestComponent<{}, {}> {
@@ -2294,6 +2214,86 @@ test("onError, eventCallback and render", async () => {
     },
     { onError },
   )
+})
+
+test("simulate a page refresh", async () => {
+  let instance: Foo
+  let mountCount = 0
+  let unmountCount = 0
+
+  class Foo extends TestComponent<{}, { text: string }> {
+    state = { text: "hi" }
+
+    constructor(props: {}) {
+      super(props)
+      instance = this
+    }
+
+    componentDidMount(): void {
+      mountCount++
+    }
+
+    componentWillUnmount(): void {
+      unmountCount++
+    }
+
+    render(): JSX.Element {
+      return <p>{this.state.text}</p>
+    }
+  }
+
+  await renderAndConnect(<Foo />, async conn => {
+    expect(mountCount).toBe(1)
+    expect(unmountCount).toBe(0)
+
+    void instance.setState({ text: "hello" })
+    await conn.messages.next()
+    conn.ws.close()
+
+    // Wait for state to be saved and unmount to occur. And wait for the state
+    // to be saved into the db to help simulate the page refresh scenario.
+    await new Promise(resolve => setTimeout(resolve, 25))
+    expect(mountCount).toBe(1)
+    expect(unmountCount).toBe(1)
+
+    const origin = `http://localhost:${conn.port}`
+    const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
+    await new Promise(resolve => ws.addEventListener("open", resolve))
+
+    const originalDeleteStateTree = reloadOptions.deleteStateTree.bind(
+      reloadOptions,
+    )
+    reloadOptions.deleteStateTree = jest.fn(async rootID => {
+      // Create an artificial delay when deleting state trees so that "connect"
+      // takes a while to let the "close" event execute before "connect"
+      // finishes.
+      await new Promise(resolve => setTimeout(resolve, 200))
+      await originalDeleteStateTree(rootID)
+    })
+    const connect: ClientMessage = {
+      type: "connect",
+      rootIDs: [conn.rootID],
+    }
+    ws.send(JSON.stringify(connect))
+    await new Promise(resolve => {
+      ws.addEventListener("message", messageEvent => {
+        // Create the race condition for having "close" execute while "connect"
+        // is executing.
+        ws.close()
+        const message: ServerMessage = JSON.parse(messageEvent.data.toString())
+        expect(message.type).toBe("update")
+        resolve()
+      })
+    })
+
+    expect(mountCount).toBe(2)
+    expect(unmountCount).toBe(1)
+
+    // Wait for state to be saved and unmount to occur in "connect."
+    await new Promise(resolve => setTimeout(resolve, 200))
+    expect(mountCount).toBe(2)
+    expect(unmountCount).toBe(2)
+  })
 })
 
 async function renderAndConnect<T>(

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -1812,6 +1812,8 @@ test("reconnect new child component mount cycle", async () => {
   await renderAndConnect(<Foo />, async conn => {
     conn.ws.close()
 
+    // Wait for state to be saved and unmount to occur.
+    await new Promise(resolve => setTimeout(resolve, 25))
     const origin = `http://localhost:${conn.port}`
     const ws = new WebSocket(`ws://localhost:${conn.port}`, { origin })
     await new Promise(resolve => ws.addEventListener("open", resolve))


### PR DESCRIPTION
## Overview
There is a race condition on a page refresh from the new "connect" event may cause the "close" event to not execute was expected because `WebSocketState.roots` may still be an empty array due to the "connect" event not completing yet.

From the email thread:
> The ["close" event](https://github.com/karthikv/purview/blob/master/src/purview.ts#L323-L341) is trying to occur while the ["connect" event](https://github.com/karthikv/purview/blob/master/src/purview.ts#L374-L461) is happening.

> If the "connect" event has not completed before the "close" event occurs, the "close" event will see the [wsState.roots](https://github.com/karthikv/purview/blob/master/src/purview.ts#L324) as [an empty array](https://github.com/karthikv/purview/blob/master/src/purview.ts#L303) which will cause the orphaned state problem. The empty array prevents tear down because "close" does not have the list of roots it needs to tear down. If we can delay the "close" event for some time (e.g., 5 seconds is what was tested) before [trying to tear down](https://github.com/karthikv/purview/blob/master/src/purview.ts#L324-L336), the orphaned state tree is able to be cleaned up as expected.


## New Logic Flow
- Set `connectionState` when the connect event has finished (e.g. "connected") and when the close event is triggered (e.g. "closing")
- At the beginning of close, if not "connected", return
- At the end of connect event, if closing, immediately trigger WebSocket clean up logic

## Testing
- Added unit test for case
  - Verified `master` failed with the new unit test
- Ran Orum locally with the new changes to make sure the previously seen behavior wasn't seen anymore