### PR TITLE
Localize JSX namespace to Purview

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid"
 import { StateTree, ChildMap, EventHandler } from "./purview"
 import { PNodeRegular } from "./types/ws"
 import { JSX } from "./purview"
+
 type UpdateFn<S> = (state: Readonly<S>) => Partial<S>
 
 export interface ComponentConstructor<P, S> {

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid"
 import { StateTree, ChildMap, EventHandler } from "./purview"
 import { PNodeRegular } from "./types/ws"
-
+import { JSX } from "./purview"
 type UpdateFn<S> = (state: Readonly<S>) => Partial<S>
 
 export interface ComponentConstructor<P, S> {

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -1,8 +1,9 @@
+import { JSX } from "./purview"
 import { Properties, SimplePseudos } from "csstype"
 import { expandProperty } from "inline-style-expand-shorthand"
 import { lexer } from "css-tree"
 import * as LRU from "lru-cache"
-import * as Purview from "./purview"
+import Purview from "./purview"
 import { isPseudoClass } from "./pseudo_classes"
 
 type OptionalProperties = {

--- a/src/css.tsx
+++ b/src/css.tsx
@@ -3,7 +3,7 @@ import { Properties, SimplePseudos } from "csstype"
 import { expandProperty } from "inline-style-expand-shorthand"
 import { lexer } from "css-tree"
 import * as LRU from "lru-cache"
-import Purview from "./purview"
+import Purview, { Component } from "./purview"
 import { isPseudoClass } from "./pseudo_classes"
 
 type OptionalProperties = {
@@ -170,7 +170,7 @@ export function styledTag<K extends keyof JSX.IntrinsicElements>(
   // Even though this is a string, it must be uppercase for JSX.
   Tag: K,
   ...baseCSSProperties: CSSProperties[]
-): new (props: JSX.IntrinsicElements[K]) => Purview.Component<
+): new (props: JSX.IntrinsicElements[K]) => Component<
   JSX.IntrinsicElements[K],
   {}
 > {

--- a/src/examples/animation.tsx
+++ b/src/examples/animation.tsx
@@ -1,4 +1,4 @@
-import Purview, { css } from "../purview"
+import Purview, { css, JSX } from "../purview"
 
 interface AnimationState {
   visible: boolean

--- a/src/examples/app.tsx
+++ b/src/examples/app.tsx
@@ -1,4 +1,4 @@
-import Purview, { ChangeEvent, css, styledTag } from "../purview"
+import Purview, { ChangeEvent, css, JSX, styledTag } from "../purview"
 import Animation from "./animation"
 
 interface AppState {

--- a/src/examples/counter.tsx
+++ b/src/examples/counter.tsx
@@ -1,6 +1,6 @@
 // Normally you'd import from "purview". We use "../purview" here since we're in
 // the Purview codebase.
-import Purview from "../purview"
+import Purview, { JSX } from "../purview"
 import { Sequelize, QueryTypes, DataTypes } from "sequelize"
 import * as http from "http"
 import * as express from "express"

--- a/src/examples/simple.tsx
+++ b/src/examples/simple.tsx
@@ -1,5 +1,5 @@
 import * as http from "http"
-import Purview, { InputEvent } from "../purview"
+import Purview, { InputEvent, JSX } from "../purview"
 import * as express from "express"
 
 // (1) Write components by extending Purview.Component. The two type parameters

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,8 @@
 import { Attrs } from "snabbdom/modules/attributes"
 import { PNodeRegular, PNode } from "./types/ws"
-import { JSX, NestedArray } from "./purview"
+import { JSX } from "./purview"
+
+export interface NestedArray<T> extends Array<NestedArray<T> | T> {}
 
 type EventAttribute = keyof JSX.DOMAttributes
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,6 @@
 import { Attrs } from "snabbdom/modules/attributes"
 import { PNodeRegular, PNode } from "./types/ws"
-import { JSX } from "./purview"
+import { JSX, NestedArray } from "./purview"
 
 type EventAttribute = keyof JSX.DOMAttributes
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,6 @@
 import { Attrs } from "snabbdom/modules/attributes"
 import { PNodeRegular, PNode } from "./types/ws"
+import { JSX } from "./purview"
 
 type EventAttribute = keyof JSX.DOMAttributes
 

--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -1,0 +1,21 @@
+import {
+  createElem as createElemInternal,
+  handleWebSocket as handleWebSocketInternal,
+  render as renderInternal,
+  renderCSS as renderCSSInternal,
+  Component as ComponentInternal,
+  scriptPath as scriptPathInternal,
+  reloadOptions as reloadOptionsInternal,
+  JSX as JSXInternal,
+} from "./purview"
+
+export namespace Purview {
+  export let createElem = createElemInternal
+  export let handleWebSocket = handleWebSocketInternal
+  export let render = renderInternal
+  export let renderCSS = renderCSSInternal
+  export let Component = ComponentInternal
+  export let scriptPath = scriptPathInternal
+  export let reloadOptions = reloadOptionsInternal
+  export import JSX = JSXInternal
+}

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -44,6 +44,7 @@ import {
   getAtomicProperties,
 } from "./css"
 import { JSX } from "./types/jsx"
+import { NestedArray } from "./types/utility"
 
 export interface RenderOptions {
   onError?: ErrorHandler
@@ -1244,4 +1245,4 @@ export {
   PurviewEvent,
 } from "./types/ws"
 export { css, styledTag, CSS } from "./css"
-export { JSX }
+export { JSX, NestedArray }

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -105,7 +105,7 @@ interface DisconnectedRoot {
   onError: ErrorHandler | null
 }
 
-interface CSSState {
+export interface CSSState {
   id: string
   // Maps a single CSS property to a class name.
   atomicCSS: Record<string, string | undefined>

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -7,6 +7,7 @@ import * as t from "io-ts"
 
 import Component, { ComponentConstructor } from "./component"
 import {
+  NestedArray,
   tryParseJSON,
   mapNested,
   isEventAttr,
@@ -44,7 +45,6 @@ import {
   getAtomicProperties,
 } from "./css"
 import { JSX } from "./types/jsx"
-import { NestedArray } from "./types/utility"
 
 export interface RenderOptions {
   onError?: ErrorHandler

--- a/src/purview.ts
+++ b/src/purview.ts
@@ -43,25 +43,13 @@ import {
   generateRule,
   getAtomicProperties,
 } from "./css"
-import { JSXInternal } from "./types/jsx"
+import { JSX } from "./types/jsx"
 
-const InternalComponent = Component
-
-declare module "http" {
-  interface IncomingMessage {
-    purviewState?: {
-      wsState: WebSocketState
-      idStateTrees: IDStateTree[]
-      roots?: ConnectedRoot[]
-    }
-    purviewCSSState?: CSSState
-    purviewCSSRendered?: boolean
-  }
-}
 export interface RenderOptions {
   onError?: ErrorHandler
 }
-interface WebSocketOptions {
+
+export interface WebSocketOptions {
   origin: string | null
 }
 
@@ -140,6 +128,18 @@ interface IDStateTree {
   stateTree: StateTree
 }
 
+declare module "http" {
+  interface IncomingMessage {
+    purviewState?: {
+      wsState: WebSocketState
+      idStateTrees: IDStateTree[]
+      roots?: ConnectedRoot[]
+    }
+    purviewCSSState?: CSSState
+    purviewCSSRendered?: boolean
+  }
+}
+
 const INPUT_TYPE_VALIDATOR: Record<
   string,
   t.Type<any, any, any> | undefined
@@ -169,8 +169,100 @@ export const RENDER_CSS_ORDERING_ERROR =
 const RENDER_CSS_NOT_CALLED_ERROR =
   "Purview: You attempted to use the css attribute in a tag, but renderCSS was never called, so Purview could not add styles. Make sure to call renderCSS and include its output in the head tag during the initial render."
 
+export function createElem(
+  nodeName: string | ComponentConstructor<any, any>,
+  attributes:
+    | (JSX.InputHTMLAttributes &
+        JSX.TextareaHTMLAttributes &
+        JSX.OptionHTMLAttributes)
+    | null,
+  ...children: NestedArray<JSX.Child>
+): JSX.Element {
+  attributes = attributes || {}
+
+  const hasSelected =
+    (nodeName === "option" && attributes.selected !== undefined) ||
+    (nodeName === "select" && containsControlledOption(children))
+
+  const isValueInput =
+    (nodeName === "input" &&
+      (!attributes.type || attributes.type === "text")) ||
+    nodeName === "textarea"
+  const hasValue = isValueInput && attributes.value !== undefined
+
+  const isCheckedInput =
+    nodeName === "input" &&
+    (attributes.type === "checkbox" || attributes.type === "radio")
+  const hasChecked = isCheckedInput && attributes.checked !== undefined
+
+  if (hasSelected || hasValue || hasChecked) {
+    ;(attributes as any)["data-controlled"] = true
+  }
+
+  if (
+    isValueInput &&
+    attributes.defaultValue !== undefined &&
+    attributes.value === undefined
+  ) {
+    attributes.value = attributes.defaultValue
+    delete attributes.defaultValue
+  }
+
+  // Must come after the defaultValue case is handled above. This ensures the
+  // defaultValue is properly written to the children.
+  if (nodeName === "textarea" && attributes.value !== undefined) {
+    children = [attributes.value]
+    delete attributes.value
+  }
+
+  if (
+    isCheckedInput &&
+    attributes.defaultChecked !== undefined &&
+    attributes.checked === undefined
+  ) {
+    attributes.checked = attributes.defaultChecked
+    delete attributes.defaultChecked
+  }
+
+  if (
+    nodeName === "option" &&
+    attributes.defaultSelected !== undefined &&
+    attributes.selected === undefined
+  ) {
+    attributes.selected = attributes.defaultSelected
+    delete attributes.defaultSelected
+  }
+
+  // For intrinsic elements, change special attributes to data-* equivalents and
+  // remove falsy attributes.
+  if (typeof nodeName === "string") {
+    if (attributes.key !== undefined) {
+      ;(attributes as any)["data-key"] = attributes.key
+      delete attributes.key
+    }
+
+    if (attributes.ignoreChildren) {
+      ;(attributes as any)["data-ignore-children"] = true
+      delete attributes.ignoreChildren
+    }
+
+    Object.keys(attributes).forEach(key => {
+      const value = (attributes as any)[key]
+      if (value === null || value === undefined || value === false) {
+        delete (attributes as any)[key]
+      }
+    })
+  }
+
+  if (children.length === 1) {
+    return { nodeName, attributes, children: children[0] }
+  } else {
+    return { nodeName, attributes, children }
+  }
+}
+
 function containsControlledOption(
-  children: JSXInternal.Child | NestedArray<JSXInternal.Child>,
+  children: JSX.Child | NestedArray<JSX.Child>,
 ): boolean {
   if (children instanceof Array) {
     const controlled = findNested(children, child => {
@@ -190,8 +282,83 @@ function containsControlledOption(
   }
 }
 
-function isControlledOption(jsx: JSXInternal.Element): boolean {
+function isControlledOption(jsx: JSX.Element): boolean {
   return jsx.nodeName === "option" && "data-controlled" in jsx.attributes
+}
+
+export function handleWebSocket(
+  server: http.Server,
+  options: WebSocketOptions,
+): WebSocket.Server {
+  const wsServer = new WebSocket.Server({
+    server,
+    verifyClient(info: { origin: string; secure: boolean }): boolean {
+      return options.origin === null || info.origin === options.origin
+    },
+  })
+
+  wsServer.on("connection", (ws, req) => {
+    if (req.method !== "GET") {
+      throw new Error("Only GET requests are supported")
+    }
+
+    const wsStateBase: WebSocketState = {
+      ws,
+      roots: [] as ConnectedRoot[],
+      connectionState: null,
+      mounted: false,
+      closing: false,
+      seenEventNames: new Set(),
+      hasCSS: false,
+    }
+    // wsStateBase is narrowed here to WebSocketStateNoCSS. This can be
+    // problematic in the handlers below because it may have changed to
+    // WebSocketStateHasCSS via the connect message. To avoid this, explicitly
+    // widen the type here.
+    const wsState = wsStateBase as WebSocketState
+
+    ws.on("message", async data => {
+      if (data === "ping") {
+        ws.send("pong")
+        return
+      }
+
+      const parsed = tryParseJSON(data.toString())
+      const decoded = clientMessageValidator.decode(parsed)
+      if (decoded.isRight()) {
+        await handleMessage(decoded.value, wsState, req, server)
+      }
+    })
+
+    ws.on("close", async () => {
+      wsState.closing = true
+      // Because both the "close" and "connect" events are async, we check if
+      // `connectionState` is set to "connected" because it could be the case
+      // that the "close" event fires just after the "connect" event (e.g., on
+      // page refresh), and the "close" event will see that the `wsState.roots`
+      // is an empty array due to the "connect" event still being in progress.
+      // This would result in an incomplete clean up of the previous
+      // connection's state. Hence, we return early, set the `closing` flag, and
+      // let the "connect" event clean up the existing state by signaling with
+      // `closing`.
+      if (wsState.connectionState !== "connected") {
+        return
+      }
+
+      await cleanUpWebSocketState(wsState)
+      wsState.closing = false
+    })
+  })
+
+  // Send pings periodically and terminate if no pong.
+  const interval = setInterval(
+    () => pingClients(wsServer, WS_PONG_TIMEOUT),
+    WS_PING_INTERVAL,
+  )
+  wsServer.on("close", () => clearInterval(interval))
+
+  server.on("close", () => wsServer.close())
+  return wsServer
 }
 
 const terminationTimers = new WeakMap<
@@ -248,7 +415,7 @@ function makeStateTree(
   const childMap: ChildMap<StateTree> = {}
   Object.keys(component._childMap).forEach(key => {
     const children = component._childMap[key]!
-    childMap[key] = children.map((c: any) =>
+    childMap[key] = children.map(c =>
       makeStateTree(c as Component<any, any>, reload),
     )
   })
@@ -280,7 +447,7 @@ async function handleMessage(
 
       const cssStateID = message.cssStateID
       if (cssStateID) {
-        const cssState = await Purview.reloadOptions.getCSSState(cssStateID)
+        const cssState = await reloadOptions.getCSSState(cssStateID)
         if (!cssState) {
           // Can't load CSS state; close WebSocket and force refresh.
           wsState.ws.close()
@@ -295,7 +462,7 @@ async function handleMessage(
       }
 
       const promises = message.rootIDs.map(async id => {
-        return { id, stateTree: await Purview.reloadOptions.getStateTree(id) }
+        return { id, stateTree: await reloadOptions.getStateTree(id) }
       })
       const idStateTrees = await Promise.all(promises)
       if (idStateTrees.some(ist => !ist.stateTree)) {
@@ -353,10 +520,10 @@ async function handleMessage(
       wsState.mounted = true
 
       const deletePromises = message.rootIDs.map(id =>
-        Purview.reloadOptions.deleteStateTree(id),
+        reloadOptions.deleteStateTree(id),
       )
       if (cssStateID) {
-        deletePromises.push(Purview.reloadOptions.deleteCSSState(cssStateID))
+        deletePromises.push(reloadOptions.deleteCSSState(cssStateID))
       }
       await Promise.all(deletePromises)
 
@@ -456,9 +623,118 @@ function sendMessage(ws: WebSocket, message: ServerMessage): void {
   }
 }
 
-function isComponentElem(
-  jsx: JSXInternal.Element,
-): jsx is JSXInternal.ComponentElement {
+export async function render(
+  jsx: JSX.Element,
+  req: http.IncomingMessage,
+  options: RenderOptions = {},
+): Promise<string> {
+  const onError = options.onError ?? null
+
+  if (!isComponentElem(jsx)) {
+    throw new Error("Root element must be a Purview.Component")
+  }
+
+  const purviewState = req.purviewState
+  let idStateTree: IDStateTree | undefined
+  if (purviewState) {
+    idStateTree = purviewState.idStateTrees.find(
+      ist => ist.stateTree.name === jsx.nodeName.getUniqueName(),
+    )
+  }
+
+  const stateTree = idStateTree && idStateTree.stateTree
+  return await withComponent(jsx, stateTree, async component => {
+    if (!component) {
+      throw new Error("Expected non-null component")
+    }
+
+    let onUnseenError: ErrorHandler | null = null
+    if (onError) {
+      onUnseenError = error => {
+        if (typeof error !== "object" || error === null) {
+          onError(error)
+          return
+        }
+
+        if (!seenErrors.has(error)) {
+          seenErrors.add(error)
+          onError(error)
+        }
+      }
+    }
+
+    let root: ConnectedRoot | DisconnectedRoot
+    if (purviewState) {
+      // This is the request from the websocket connection.
+      component._id = idStateTree!.id
+      root = {
+        connected: true,
+        component,
+        wsState: purviewState.wsState,
+        eventNames: new Set(),
+        aliases: {},
+        allComponentsMap: { [component._id]: component },
+        onError: onUnseenError,
+      }
+      purviewState.roots = purviewState.roots || []
+      purviewState.roots.push(root)
+    } else {
+      // This is the initial render.
+      req.purviewCSSState = req.purviewCSSState ?? {
+        id: nanoid(),
+        atomicCSS: {},
+        cssRules: [],
+        nextRuleIndex: 0,
+      }
+      if (req.purviewCSSRendered) {
+        throw new Error(RENDER_CSS_ORDERING_ERROR)
+      }
+      root = {
+        connected: false,
+        cssState: req.purviewCSSState,
+        onError: onUnseenError,
+      }
+    }
+
+    const pNode = await renderComponent(component, component._id, root)
+    if (!pNode) {
+      throw new Error("Expected non-null node")
+    }
+
+    if (purviewState) {
+      return ""
+    } else {
+      await reloadOptions.saveStateTree(
+        component._id,
+        makeStateTree(component, false),
+      )
+      return toHTML(pNode)
+    }
+  })
+}
+
+export async function renderCSS(req: http.IncomingMessage): Promise<string> {
+  const cssState = req.purviewCSSState
+  if (!cssState) {
+    req.purviewCSSRendered = true
+    return ""
+  }
+
+  const { id, cssRules } = cssState
+  const textPNode = createTextPNode(cssRules.join("\n"))
+  const pNode = createPNode(
+    "style",
+    { id: STYLE_TAG_ID, "data-css-state-id": id },
+    [textPNode],
+  )
+
+  cssState.nextRuleIndex = cssRules.length
+  await reloadOptions.saveCSSState(id, cssState)
+  req.purviewCSSRendered = true
+  return toHTML(pNode)
+}
+
+function isComponentElem(jsx: JSX.Element): jsx is JSX.ComponentElement {
   return (
     typeof jsx.nodeName === "function" &&
     jsx.nodeName.prototype &&
@@ -467,7 +743,7 @@ function isComponentElem(
 }
 
 async function makeElem(
-  jsx: JSXInternal.Element,
+  jsx: JSX.Element,
   parent: Component<any, any>,
   rootID: string,
   root: ConnectedRoot | DisconnectedRoot,
@@ -512,7 +788,7 @@ async function makeElem(
 }
 
 async function makeRegularElem(
-  jsx: JSXInternal.Element,
+  jsx: JSX.Element,
   parent: Component<any, any>,
   rootID: string,
   root: ConnectedRoot | DisconnectedRoot,
@@ -572,12 +848,10 @@ async function makeRegularElem(
           }
 
           if (nodeName === "input") {
-            const type = (attributes as JSXInternal.InputHTMLAttributes)
-              .type as string
+            const type = (attributes as JSX.InputHTMLAttributes).type as string
             validator = makeValidator(INPUT_TYPE_VALIDATOR[type] || t.string)
           } else if (nodeName === "select") {
-            const multiple = (attributes as JSXInternal.SelectHTMLAttributes)
-              .multiple
+            const multiple = (attributes as JSX.SelectHTMLAttributes).multiple
             validator = makeValidator(multiple ? t.array(t.string) : t.string)
           } else if (nodeName === "textarea") {
             validator = makeValidator(t.string)
@@ -670,7 +944,7 @@ async function makeRegularElem(
 }
 
 function makeChild(
-  child: JSXInternal.Child,
+  child: JSX.Child,
   parent: Component<any, any>,
   rootID: string,
   root: ConnectedRoot | DisconnectedRoot,
@@ -688,7 +962,7 @@ function makeChild(
 }
 
 async function withComponent<T>(
-  jsx: JSXInternal.ComponentElement,
+  jsx: JSX.ComponentElement,
   existing: Component<any, any> | StateTree | null | undefined,
   callback: (component: Component<any, any> | null) => T,
   root?: ConnectedRoot | DisconnectedRoot,
@@ -764,7 +1038,7 @@ async function renderComponent(
   const newChildMap: ChildMap<Component<any, any>> = {}
   Object.keys(component._newChildMap).forEach(key => {
     newChildMap[key] = component._newChildMap[key]!.filter(
-      (c: any) => c !== null,
+      c => c !== null,
     ) as Array<Component<any, any>>
   })
 
@@ -874,7 +1148,7 @@ function unmountChildren(
 ): void {
   Object.keys(component._childMap).forEach(key => {
     const children = component._childMap[key]!
-    children.forEach((child: any) => {
+    children.forEach(child => {
       if (child instanceof Component) {
         // Don't wait for this; unmounting is an asynchronous event.
         void child._triggerUnmount(
@@ -897,11 +1171,11 @@ function unalias(id: string, root: ConnectedRoot): string {
 async function cleanUpWebSocketState(wsState: WebSocketState): Promise<void> {
   const promises = wsState.roots.map(async root => {
     const stateTree = makeStateTree(root.component, true)
-    await Purview.reloadOptions.saveStateTree(root.component._id, stateTree)
+    await reloadOptions.saveStateTree(root.component._id, stateTree)
     await root.component._triggerUnmount(root.allComponentsMap)
   })
   if (wsState.hasCSS) {
-    const cssPromise = Purview.reloadOptions.saveCSSState(
+    const cssPromise = reloadOptions.saveCSSState(
       wsState.cssState.id,
       wsState.cssState,
     )
@@ -914,332 +1188,52 @@ const globalStateTrees: Record<string, StateTree | undefined> = {}
 const globalCSSState: Record<string, CSSState | undefined> = {}
 const DELETE_INTERVAL = 60 * 1000 // 60 seconds
 
-namespace Purview {
-  export function createElem(
-    nodeName: string | ComponentConstructor<any, any>,
-    attributes:
-      | (JSXInternal.InputHTMLAttributes &
-          JSXInternal.TextareaHTMLAttributes &
-          JSXInternal.OptionHTMLAttributes)
-      | null,
-    ...children: NestedArray<JSXInternal.Child>
-  ): JSXInternal.Element {
-    attributes = attributes || {}
-
-    const hasSelected =
-      (nodeName === "option" && attributes.selected !== undefined) ||
-      (nodeName === "select" && containsControlledOption(children))
-
-    const isValueInput =
-      (nodeName === "input" &&
-        (!attributes.type || attributes.type === "text")) ||
-      nodeName === "textarea"
-    const hasValue = isValueInput && attributes.value !== undefined
-
-    const isCheckedInput =
-      nodeName === "input" &&
-      (attributes.type === "checkbox" || attributes.type === "radio")
-    const hasChecked = isCheckedInput && attributes.checked !== undefined
-
-    if (hasSelected || hasValue || hasChecked) {
-      ;(attributes as any)["data-controlled"] = true
+export const reloadOptions = {
+  async saveStateTree(id: string, tree: StateTree): Promise<void> {
+    globalStateTrees[id] = tree
+    if (process.env.NODE_ENV !== "test") {
+      setTimeout(() => this.deleteStateTree(id), DELETE_INTERVAL)
     }
+  },
 
-    if (
-      isValueInput &&
-      attributes.defaultValue !== undefined &&
-      attributes.value === undefined
-    ) {
-      attributes.value = attributes.defaultValue
-      delete attributes.defaultValue
+  async getStateTree(id: string): Promise<StateTree | null> {
+    return globalStateTrees[id] ?? null
+  },
+
+  async deleteStateTree(id: string): Promise<void> {
+    delete globalStateTrees[id]
+  },
+
+  async saveCSSState(id: string, cssState: CSSState): Promise<void> {
+    globalCSSState[id] = cssState
+    if (process.env.NODE_ENV !== "test") {
+      setTimeout(() => this.deleteCSSState(id), DELETE_INTERVAL)
     }
+  },
 
-    // Must come after the defaultValue case is handled above. This ensures the
-    // defaultValue is properly written to the children.
-    if (nodeName === "textarea" && attributes.value !== undefined) {
-      children = [attributes.value]
-      delete attributes.value
-    }
+  async getCSSState(id: string): Promise<CSSState | null> {
+    return globalCSSState[id] ?? null
+  },
 
-    if (
-      isCheckedInput &&
-      attributes.defaultChecked !== undefined &&
-      attributes.checked === undefined
-    ) {
-      attributes.checked = attributes.defaultChecked
-      delete attributes.defaultChecked
-    }
-
-    if (
-      nodeName === "option" &&
-      attributes.defaultSelected !== undefined &&
-      attributes.selected === undefined
-    ) {
-      attributes.selected = attributes.defaultSelected
-      delete attributes.defaultSelected
-    }
-
-    // For intrinsic elements, change special attributes to data-* equivalents and
-    // remove falsy attributes.
-    if (typeof nodeName === "string") {
-      if (attributes.key !== undefined) {
-        ;(attributes as any)["data-key"] = attributes.key
-        delete attributes.key
-      }
-
-      if (attributes.ignoreChildren) {
-        ;(attributes as any)["data-ignore-children"] = true
-        delete attributes.ignoreChildren
-      }
-
-      Object.keys(attributes).forEach(key => {
-        const value = (attributes as any)[key]
-        if (value === null || value === undefined || value === false) {
-          delete (attributes as any)[key]
-        }
-      })
-    }
-
-    if (children.length === 1) {
-      return { nodeName, attributes, children: children[0] }
-    } else {
-      return { nodeName, attributes, children }
-    }
-  }
-  export function handleWebSocket(
-    server: http.Server,
-    options: WebSocketOptions,
-  ): WebSocket.Server {
-    const wsServer = new WebSocket.Server({
-      server,
-      verifyClient(info: { origin: string; secure: boolean }): boolean {
-        return options.origin === null || info.origin === options.origin
-      },
-    })
-
-    wsServer.on("connection", (ws, req) => {
-      if (req.method !== "GET") {
-        throw new Error("Only GET requests are supported")
-      }
-
-      const wsStateBase: WebSocketState = {
-        ws,
-        roots: [] as ConnectedRoot[],
-        connectionState: null,
-        mounted: false,
-        closing: false,
-        seenEventNames: new Set(),
-        hasCSS: false,
-      }
-      // wsStateBase is narrowed here to WebSocketStateNoCSS. This can be
-      // problematic in the handlers below because it may have changed to
-      // WebSocketStateHasCSS via the connect message. To avoid this, explicitly
-      // widen the type here.
-      const wsState = wsStateBase as WebSocketState
-
-      ws.on("message", async data => {
-        if (data === "ping") {
-          ws.send("pong")
-          return
-        }
-
-        const parsed = tryParseJSON(data.toString())
-        const decoded = clientMessageValidator.decode(parsed)
-        if (decoded.isRight()) {
-          await handleMessage(decoded.value, wsState, req, server)
-        }
-      })
-
-      ws.on("close", async () => {
-        wsState.closing = true
-        // Because both the "close" and "connect" events are async, we check if
-        // `connectionState` is set to "connected" because it could be the case
-        // that the "close" event fires just after the "connect" event (e.g., on
-        // page refresh), and the "close" event will see that the `wsState.roots`
-        // is an empty array due to the "connect" event still being in progress.
-        // This would result in an incomplete clean up of the previous
-        // connection's state. Hence, we return early, set the `closing` flag, and
-        // let the "connect" event clean up the existing state by signaling with
-        // `closing`.
-        if (wsState.connectionState !== "connected") {
-          return
-        }
-
-        await cleanUpWebSocketState(wsState)
-        wsState.closing = false
-      })
-    })
-
-    // Send pings periodically and terminate if no pong.
-    const interval = setInterval(
-      () => pingClients(wsServer, WS_PONG_TIMEOUT),
-      WS_PING_INTERVAL,
-    )
-    wsServer.on("close", () => clearInterval(interval))
-
-    server.on("close", () => wsServer.close())
-    return wsServer
-  }
-
-  export async function render(
-    jsx: JSXInternal.Element,
-    req: http.IncomingMessage,
-    options: RenderOptions = {},
-  ): Promise<string> {
-    const onError = options.onError ?? null
-
-    if (!isComponentElem(jsx)) {
-      throw new Error("Root element must be a Purview.Component")
-    }
-
-    const purviewState = req.purviewState
-    let idStateTree: IDStateTree | undefined
-    if (purviewState) {
-      idStateTree = purviewState.idStateTrees.find(
-        ist => ist.stateTree.name === jsx.nodeName.getUniqueName(),
-      )
-    }
-
-    const stateTree = idStateTree && idStateTree.stateTree
-    return await withComponent(jsx, stateTree, async component => {
-      if (!component) {
-        throw new Error("Expected non-null component")
-      }
-
-      let onUnseenError: ErrorHandler | null = null
-      if (onError) {
-        onUnseenError = error => {
-          if (typeof error !== "object" || error === null) {
-            onError(error)
-            return
-          }
-
-          if (!seenErrors.has(error)) {
-            seenErrors.add(error)
-            onError(error)
-          }
-        }
-      }
-
-      let root: ConnectedRoot | DisconnectedRoot
-      if (purviewState) {
-        // This is the request from the websocket connection.
-        component._id = idStateTree!.id
-        root = {
-          connected: true,
-          component,
-          wsState: purviewState.wsState,
-          eventNames: new Set(),
-          aliases: {},
-          allComponentsMap: { [component._id]: component },
-          onError: onUnseenError,
-        }
-        purviewState.roots = purviewState.roots || []
-        purviewState.roots.push(root)
-      } else {
-        // This is the initial render.
-        req.purviewCSSState = req.purviewCSSState ?? {
-          id: nanoid(),
-          atomicCSS: {},
-          cssRules: [],
-          nextRuleIndex: 0,
-        }
-        if (req.purviewCSSRendered) {
-          throw new Error(RENDER_CSS_ORDERING_ERROR)
-        }
-        root = {
-          connected: false,
-          cssState: req.purviewCSSState,
-          onError: onUnseenError,
-        }
-      }
-
-      const pNode = await renderComponent(component, component._id, root)
-      if (!pNode) {
-        throw new Error("Expected non-null node")
-      }
-
-      if (purviewState) {
-        return ""
-      } else {
-        await reloadOptions.saveStateTree(
-          component._id,
-          makeStateTree(component, false),
-        )
-        return toHTML(pNode)
-      }
-    })
-  }
-
-  export async function renderCSS(req: http.IncomingMessage): Promise<string> {
-    const cssState = req.purviewCSSState
-    if (!cssState) {
-      req.purviewCSSRendered = true
-      return ""
-    }
-
-    const { id, cssRules } = cssState
-    const textPNode = createTextPNode(cssRules.join("\n"))
-    const pNode = createPNode(
-      "style",
-      { id: STYLE_TAG_ID, "data-css-state-id": id },
-      [textPNode],
-    )
-
-    cssState.nextRuleIndex = cssRules.length
-    await reloadOptions.saveCSSState(id, cssState)
-    req.purviewCSSRendered = true
-    return toHTML(pNode)
-  }
-  export import JSX = JSXInternal
-
-  export const reloadOptions = {
-    async saveStateTree(id: string, tree: StateTree): Promise<void> {
-      globalStateTrees[id] = tree
-      if (process.env.NODE_ENV !== "test") {
-        setTimeout(() => this.deleteStateTree(id), DELETE_INTERVAL)
-      }
-    },
-
-    async getStateTree(id: string): Promise<StateTree | null> {
-      return globalStateTrees[id] ?? null
-    },
-
-    async deleteStateTree(id: string): Promise<void> {
-      delete globalStateTrees[id]
-    },
-
-    async saveCSSState(id: string, cssState: CSSState): Promise<void> {
-      globalCSSState[id] = cssState
-      if (process.env.NODE_ENV !== "test") {
-        setTimeout(() => this.deleteCSSState(id), DELETE_INTERVAL)
-      }
-    },
-
-    async getCSSState(id: string): Promise<CSSState | null> {
-      return globalCSSState[id] ?? null
-    },
-
-    async deleteCSSState(id: string): Promise<void> {
-      delete globalCSSState[id]
-    },
-  }
-  export const scriptPath = pathLib.resolve(
-    __dirname,
-    "..",
-    "dist",
-    "bundle",
-    "browser.js",
-  )
-  // tslint:disable-next-line
-  export abstract class Component<P, S> extends InternalComponent<P, S> {}
+  async deleteCSSState(id: string): Promise<void> {
+    delete globalCSSState[id]
+  },
 }
 
-Purview.Component = Component
-
-export default Purview
-
 export { Component }
+export const scriptPath = pathLib.resolve(
+  __dirname,
+  "..",
+  "dist",
+  "bundle",
+  "browser.js",
+)
+
+// Export all values above on the default object as well. Do this through
+// a namespace so we can use a locally scoped JSX namespace:
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#locally-scoped-jsx-namespaces
+import { Purview } from "./namespace"
+export default Purview
 
 // Export relevant types.
 export {
@@ -1250,4 +1244,4 @@ export {
   PurviewEvent,
 } from "./types/ws"
 export { css, styledTag, CSS } from "./css"
-export { JSXInternal as JSX }
+export { JSX }

--- a/src/types/jsx.ts
+++ b/src/types/jsx.ts
@@ -7,7 +7,7 @@ declare global {
   interface NestedArray<T> extends Array<NestedArray<T> | T> {}
 }
 
-export namespace JSXInternal {
+export namespace JSX {
   export interface Element<T = HTMLAttributes> {
     nodeName: string | ComponentConstructor<any, any>
     attributes: T
@@ -656,13 +656,7 @@ export namespace JSXInternal {
     width?: number | string
   }
 
-  export type Child =
-    | string
-    | number
-    | boolean
-    | null
-    | undefined
-    | JSXInternal.Element
+  export type Child = string | number | boolean | null | undefined | JSX.Element
 
   export interface HTMLAttributes extends DOMAttributes {
     // Purview specific

--- a/src/types/jsx.ts
+++ b/src/types/jsx.ts
@@ -5,1126 +5,1125 @@ import { CSS } from "../css"
 /* tslint:disable no-namespace */
 declare global {
   interface NestedArray<T> extends Array<NestedArray<T> | T> {}
-
-  namespace JSX {
-    interface Element<T = HTMLAttributes> {
-      nodeName: string | ComponentConstructor<any, any>
-      attributes: T
-      children: Child | NestedArray<Child>
-    }
-    interface ComponentElement<T = HTMLAttributes> extends Element<T> {
-      nodeName: ComponentConstructor<any, any>
-    }
-    interface NormalElement<T = HTMLAttributes> extends Element<T> {
-      nodeName: string
-    }
-
-    interface ElementClass extends Component<any, any> {}
-    interface ElementAttributesProperty {
-      props: {}
-    }
-    interface ElementChildrenAttribute {
-      children: {}
-    }
-
-    // Everything below is taken from:
-    // https://github.com/ionic-team/stencil/blob/master/src/declarations/jsx.ts
-    interface IntrinsicElements {
-      // HTML
-      a: AnchorHTMLAttributes<HTMLAnchorElement>
-      abbr: HTMLAttributes
-      address: HTMLAttributes
-      area: AreaHTMLAttributes<HTMLAreaElement>
-      article: HTMLAttributes
-      aside: HTMLAttributes
-      audio: AudioHTMLAttributes<HTMLAudioElement>
-      b: HTMLAttributes
-      base: BaseHTMLAttributes<HTMLBaseElement>
-      bdi: HTMLAttributes
-      bdo: HTMLAttributes
-      big: HTMLAttributes
-      blockquote: BlockquoteHTMLAttributes<HTMLQuoteElement>
-      body: HTMLAttributes<HTMLBodyElement>
-      br: HTMLAttributes<HTMLBRElement>
-      button: ButtonHTMLAttributes<HTMLButtonElement>
-      canvas: CanvasHTMLAttributes<HTMLCanvasElement>
-      caption: HTMLAttributes<HTMLTableCaptionElement>
-      cite: HTMLAttributes
-      code: HTMLAttributes
-      col: ColHTMLAttributes<HTMLTableColElement>
-      colgroup: ColgroupHTMLAttributes<HTMLTableColElement>
-      data: HTMLAttributes<HTMLDataElement>
-      datalist: HTMLAttributes<HTMLDataListElement>
-      dd: HTMLAttributes
-      del: DelHTMLAttributes<HTMLModElement>
-      details: DetailsHTMLAttributes<HTMLElement>
-      dfn: HTMLAttributes
-      dialog: DialogHTMLAttributes<HTMLDialogElement>
-      div: HTMLAttributes<HTMLDivElement>
-      dl: HTMLAttributes<HTMLDListElement>
-      dt: HTMLAttributes
-      em: HTMLAttributes
-      embed: EmbedHTMLAttributes<HTMLEmbedElement>
-      fieldset: FieldsetHTMLAttributes<HTMLFieldSetElement>
-      figcaption: HTMLAttributes
-      figure: HTMLAttributes
-      footer: HTMLAttributes
-      form: FormHTMLAttributes<HTMLFormElement>
-      h1: HTMLAttributes<HTMLHeadingElement>
-      h2: HTMLAttributes<HTMLHeadingElement>
-      h3: HTMLAttributes<HTMLHeadingElement>
-      h4: HTMLAttributes<HTMLHeadingElement>
-      h5: HTMLAttributes<HTMLHeadingElement>
-      h6: HTMLAttributes<HTMLHeadingElement>
-      head: HTMLAttributes<HTMLHeadElement>
-      header: HTMLAttributes
-      hgroup: HTMLAttributes
-      hr: HTMLAttributes<HTMLHRElement>
-      html: HTMLAttributes<HTMLHtmlElement>
-      i: HTMLAttributes
-      iframe: IframeHTMLAttributes<HTMLIFrameElement>
-      img: ImgHTMLAttributes<HTMLImageElement>
-      input:
-        | CheckboxInputHTMLAttributes<HTMLInputElement>
-        | NumberInputHTMLAttributes<HTMLInputElement>
-        | TextInputHTMLAttributes<HTMLInputElement>
-      ins: InsHTMLAttributes<HTMLModElement>
-      kbd: HTMLAttributes
-      keygen: KeygenHTMLAttributes<HTMLElement>
-      label: LabelHTMLAttributes<HTMLLabelElement>
-      legend: HTMLAttributes<HTMLLegendElement>
-      li: LiHTMLAttributes<HTMLLIElement>
-      link: LinkHTMLAttributes<HTMLLinkElement>
-      main: HTMLAttributes
-      map: MapHTMLAttributes<HTMLMapElement>
-      mark: HTMLAttributes
-      menu: MenuHTMLAttributes<HTMLMenuElement>
-      menuitem: HTMLAttributes
-      meta: MetaHTMLAttributes<HTMLMetaElement>
-      meter: MeterHTMLAttributes<HTMLMeterElement>
-      nav: HTMLAttributes
-      noscript: HTMLAttributes
-      object: ObjectHTMLAttributes<HTMLObjectElement>
-      ol: OlHTMLAttributes<HTMLOListElement>
-      optgroup: OptgroupHTMLAttributes<HTMLOptGroupElement>
-      option: OptionHTMLAttributes<HTMLOptionElement>
-      output: OutputHTMLAttributes<HTMLOutputElement>
-      p: HTMLAttributes<HTMLParagraphElement>
-      param: ParamHTMLAttributes<HTMLParamElement>
-      picture: HTMLAttributes<HTMLPictureElement>
-      pre: HTMLAttributes<HTMLPreElement>
-      progress: ProgressHTMLAttributes<HTMLProgressElement>
-      q: QuoteHTMLAttributes<HTMLQuoteElement>
-      rp: HTMLAttributes
-      rt: HTMLAttributes
-      ruby: HTMLAttributes
-      s: HTMLAttributes
-      samp: HTMLAttributes
-      script: ScriptHTMLAttributes<HTMLScriptElement>
-      section: HTMLAttributes
-      select:
-        | MultiSelectHTMLAttributes<HTMLSelectElement>
-        | SingleSelectHTMLAttributes<HTMLSelectElement>
-      small: HTMLAttributes
-      source: SourceHTMLAttributes<HTMLSourceElement>
-      span: HTMLAttributes<HTMLSpanElement>
-      strong: HTMLAttributes
-      style: StyleHTMLAttributes<HTMLStyleElement>
-      sub: HTMLAttributes
-      summary: HTMLAttributes
-      sup: HTMLAttributes
-      table: TableHTMLAttributes<HTMLTableElement>
-      tbody: HTMLAttributes<HTMLTableSectionElement>
-      td: TdHTMLAttributes<HTMLTableDataCellElement>
-      textarea: TextareaHTMLAttributes<HTMLTextAreaElement>
-      tfoot: HTMLAttributes<HTMLTableSectionElement>
-      th: ThHTMLAttributes<HTMLTableHeaderCellElement>
-      thead: HTMLAttributes<HTMLTableSectionElement>
-      time: TimeHTMLAttributes<HTMLTimeElement>
-      title: HTMLAttributes<HTMLTitleElement>
-      tr: HTMLAttributes<HTMLTableRowElement>
-      track: TrackHTMLAttributes<HTMLTrackElement>
-      u: HTMLAttributes
-      ul: HTMLAttributes<HTMLUListElement>
-      var: HTMLAttributes
-      video: VideoHTMLAttributes<HTMLVideoElement>
-      wbr: HTMLAttributes
-    }
-
-    export interface AnchorHTMLAttributes<T> extends HTMLAttributes<T> {
-      download?: any
-      href?: string
-      hrefLang?: string
-      hreflang?: string
-      media?: string
-      rel?: string
-      target?: string
-    }
-
-    export interface AudioHTMLAttributes<T> extends MediaHTMLAttributes<T> {}
-
-    export interface AreaHTMLAttributes<T> extends HTMLAttributes<T> {
-      alt?: string
-      coords?: string
-      download?: any
-      href?: string
-      hrefLang?: string
-      hreflang?: string
-      media?: string
-      rel?: string
-      shape?: string
-      target?: string
-    }
-
-    export interface BaseHTMLAttributes<T> extends HTMLAttributes<T> {
-      href?: string
-      target?: string
-    }
-
-    export interface BlockquoteHTMLAttributes<T> extends HTMLAttributes<T> {
-      cite?: string
-    }
-
-    export interface ButtonHTMLAttributes<T> extends HTMLAttributes<T> {
-      autoFocus?: boolean
-      disabled?: boolean
-      form?: string
-      formAction?: string
-      formaction?: string
-      formEncType?: string
-      formenctype?: string
-      formMethod?: string
-      formmethod?: string
-      formNoValidate?: boolean
-      formnovalidate?: boolean
-      formTarget?: string
-      formtarget?: string
-      name?: string
-      type?: string
-      value?: string | number
-    }
-
-    export interface CanvasHTMLAttributes<T> extends HTMLAttributes<T> {
-      height?: number | string
-      width?: number | string
-    }
-
-    export interface ColHTMLAttributes<T> extends HTMLAttributes<T> {
-      span?: number
-    }
-
-    export interface ColgroupHTMLAttributes<T> extends HTMLAttributes<T> {
-      span?: number
-    }
-
-    export interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
-      open?: boolean
-    }
-
-    export interface DelHTMLAttributes<T> extends HTMLAttributes<T> {
-      cite?: string
-      dateTime?: string
-      datetime?: string
-    }
-
-    export interface DialogHTMLAttributes<T> extends HTMLAttributes<T> {
-      open?: boolean
-      returnValue?: string
-    }
-
-    export interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
-      height?: number | string
-      src?: string
-      type?: string
-      width?: number | string
-    }
-
-    export interface FieldsetHTMLAttributes<T> extends HTMLAttributes<T> {
-      disabled?: boolean
-      form?: string
-      name?: string
-    }
-
-    export interface FormHTMLAttributes<T> extends HTMLAttributes<T> {
-      acceptCharset?: string
-      acceptcharset?: string
-      action?: string
-      autoComplete?: string
-      autocomplete?: string
-      encType?: string
-      enctype?: string
-      method?: string
-      name?: string
-      noValidate?: boolean
-      novalidate?: boolean | string
-      target?: string
-    }
-
-    export interface HtmlHTMLAttributes<T> extends HTMLAttributes<T> {
-      manifest?: string
-    }
-
-    export interface IframeHTMLAttributes<T> extends HTMLAttributes<T> {
-      allowFullScreen?: boolean
-      allowfullScreen?: string | boolean
-      allowTransparency?: boolean
-      allowtransparency?: string | boolean
-      frameBorder?: number | string
-      frameborder?: number | string
-      height?: number | string
-      marginHeight?: number
-      marginheight?: string | number
-      marginWidth?: number
-      marginwidth?: string | number
-      name?: string
-      sandbox?: string
-      scrolling?: string
-      seamless?: boolean
-      src?: string
-      srcDoc?: string
-      srcdoc?: string
-      width?: number | string
-    }
-
-    export interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
-      alt?: string
-      decoding?: "async" | "auto" | "sync"
-      height?: number | string
-      sizes?: string
-      src?: string
-      srcSet?: string
-      srcset?: string
-      useMap?: string
-      usemap?: string
-      width?: number | string
-    }
-
-    export interface InsHTMLAttributes<T> extends HTMLAttributes<T> {
-      cite?: string
-      dateTime?: string
-      datetime?: string
-    }
-
-    export interface CheckboxInputHTMLAttributes<T>
-      extends Omit<InputHTMLAttributes<T>, "onChange" | "onInput"> {
-      type: "checkbox"
-      onChange?: (event: ChangeEvent<boolean>) => void
-      onInput?: (event: InputEvent<boolean>) => void
-    }
-
-    export interface NumberInputHTMLAttributes<T>
-      extends Omit<InputHTMLAttributes<T>, "onChange" | "onInput"> {
-      type: "number"
-      onChange?: (event: ChangeEvent<number>) => void
-      onInput?: (event: InputEvent<number>) => void
-    }
-
-    export interface TextInputHTMLAttributes<T>
-      extends Omit<InputHTMLAttributes<T>, "onChange" | "onInput"> {
-      type?: Exclude<InputType, "checkbox" | "number">
-      onChange?: (event: ChangeEvent<string>) => void
-      onInput?: (event: InputEvent<string>) => void
-    }
-
-    export type InputType =
-      | "button"
-      | "checkbox"
-      | "color"
-      | "date"
-      | "datetime"
-      | "datetime-local"
-      | "email"
-      | "file"
-      | "hidden"
-      | "image"
-      | "month"
-      | "number"
-      | "password"
-      | "radio"
-      | "range"
-      | "reset"
-      | "search"
-      | "submit"
-      | "tel"
-      | "text"
-      | "time"
-      | "url"
-      | "week"
-
-    export interface InputHTMLAttributes<T> extends HTMLAttributes<T> {
-      // Purview specific
-      defaultValue?: string | number
-      defaultChecked?: boolean
-
-      // Standard HTML Attributes
-      accept?: string
-      alt?: string
-      autoComplete?: string
-      autocomplete?: string
-      autoFocus?: boolean
-      autofocus?: boolean | string
-      capture?: string // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
-      checked?: boolean
-      crossOrigin?: string
-      crossorigin?: string
-      disabled?: boolean
-      form?: string
-      formAction?: string
-      formaction?: string
-      formEncType?: string
-      formenctype?: string
-      formMethod?: string
-      formmethod?: string
-      formNoValidate?: boolean
-      formnovalidate?: boolean
-      formTarget?: string
-      formtarget?: string
-      height?: number | string
-      list?: string
-      max?: number | string
-      maxLength?: number
-      maxlength?: number | string
-      min?: number | string
-      minLength?: number
-      minlength?: number | string
-      multiple?: boolean
-      name?: string
-      pattern?: string
-      placeholder?: string
-      readOnly?: boolean
-      readonly?: boolean | string
-      required?: boolean
-      size?: number
-      src?: string
-      step?: number | string
-      type?: InputType
-      value?: string | number
-      width?: number | string
-    }
-
-    export interface KeygenHTMLAttributes<T> extends HTMLAttributes<T> {
-      autoFocus?: boolean
-      autofocus?: boolean | string
-      challenge?: string
-      disabled?: boolean
-      form?: string
-      keyType?: string
-      keytype?: string
-      keyParams?: string
-      keyparams?: string
-      name?: string
-    }
-
-    export interface LabelHTMLAttributes<T> extends HTMLAttributes<T> {
-      form?: string
-      htmlFor?: string
-      htmlfor?: string
-    }
-
-    export interface LiHTMLAttributes<T> extends HTMLAttributes<T> {
-      value?: string | number
-    }
-
-    export interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
-      href?: string
-      hrefLang?: string
-      hreflang?: string
-      integrity?: string
-      media?: string
-      rel?: string
-      sizes?: string
-      type?: string
-    }
-
-    export interface MapHTMLAttributes<T> extends HTMLAttributes<T> {
-      name?: string
-    }
-
-    export interface MenuHTMLAttributes<T> extends HTMLAttributes<T> {
-      type?: string
-    }
-
-    export interface MediaHTMLAttributes<T> extends HTMLAttributes<T> {
-      autoPlay?: boolean
-      autoplay?: boolean | string
-      controls?: boolean
-      crossOrigin?: string
-      crossorigin?: string
-      loop?: boolean
-      mediaGroup?: string
-      mediagroup?: string
-      muted?: boolean
-      preload?: string
-      src?: string
-    }
-
-    export interface MetaHTMLAttributes<T> extends HTMLAttributes<T> {
-      charSet?: string
-      charset?: string
-      content?: string
-      httpEquiv?: string
-      httpequiv?: string
-      name?: string
-    }
-
-    export interface MeterHTMLAttributes<T> extends HTMLAttributes<T> {
-      form?: string
-      high?: number
-      low?: number
-      max?: number | string
-      min?: number | string
-      optimum?: number
-      value?: string | number
-    }
-
-    export interface QuoteHTMLAttributes<T> extends HTMLAttributes<T> {
-      cite?: string
-    }
-
-    export interface ObjectHTMLAttributes<T> extends HTMLAttributes<T> {
-      classID?: string
-      classid?: string
-      data?: string
-      form?: string
-      height?: number | string
-      name?: string
-      type?: string
-      useMap?: string
-      usemap?: string
-      width?: number | string
-      wmode?: string
-    }
-
-    export interface OlHTMLAttributes<T> extends HTMLAttributes<T> {
-      reversed?: boolean
-      start?: number
-    }
-
-    export interface OptgroupHTMLAttributes<T> extends HTMLAttributes<T> {
-      disabled?: boolean
-      label?: string
-    }
-
-    export interface OptionHTMLAttributes<T> extends HTMLAttributes<T> {
-      // Purview specific
-      defaultSelected?: boolean
-
-      // Standard HTML attributes
-      disabled?: boolean
-      label?: string
-      selected?: boolean
-      value?: string | number
-    }
-
-    export interface OutputHTMLAttributes<T> extends HTMLAttributes<T> {
-      form?: string
-      htmlFor?: string
-      htmlfor?: string
-      name?: string
-    }
-
-    export interface ParamHTMLAttributes<T> extends HTMLAttributes<T> {
-      name?: string
-      value?: string | number
-    }
-
-    export interface ProgressHTMLAttributes<T> extends HTMLAttributes<T> {
-      max?: number | string
-      value?: string | number
-    }
-
-    export interface ScriptHTMLAttributes<T> extends HTMLAttributes<T> {
-      async?: boolean
-      charSet?: string
-      charset?: string
-      crossOrigin?: string
-      crossorigin?: string
-      defer?: boolean
-      integrity?: string
-      nonce?: string
-      src?: string
-      type?: string
-    }
-
-    export interface MultiSelectHTMLAttributes<T>
-      extends Omit<SelectHTMLAttributes<T>, "onChange" | "onInput"> {
-      multiple: true
-      onChange?: (event: ChangeEvent<string[]>) => void
-      onInput?: (event: InputEvent<string[]>) => void
-    }
-
-    export interface SingleSelectHTMLAttributes<T>
-      extends Omit<SelectHTMLAttributes<T>, "onChange" | "onInput"> {
-      multiple?: false
-      onChange?: (event: ChangeEvent<string>) => void
-      onInput?: (event: InputEvent<string>) => void
-    }
-
-    export interface SelectHTMLAttributes<T> extends HTMLAttributes<T> {
-      autoFocus?: boolean
-      autoComplete?: string
-      autocomplete?: string
-      disabled?: boolean
-      form?: string
-      multiple?: boolean
-      name?: string
-      required?: boolean
-      size?: number
-    }
-
-    export interface SourceHTMLAttributes<T> extends HTMLAttributes<T> {
-      media?: string
-      sizes?: string
-      src?: string
-      srcSet?: string
-      type?: string
-    }
-
-    export interface StyleHTMLAttributes<T> extends HTMLAttributes<T> {
-      media?: string
-      nonce?: string
-      scoped?: boolean
-      type?: string
-    }
-
-    export interface TableHTMLAttributes<T> extends HTMLAttributes<T> {
-      cellPadding?: number | string
-      cellpadding?: number | string
-      cellSpacing?: number | string
-      cellspacing?: number | string
-      summary?: string
-    }
-
-    export interface TextareaHTMLAttributes<T> extends HTMLAttributes<T> {
-      // Purview specific
-      defaultValue?: string | number
-
-      // Standard HTML attributes
-      autoFocus?: boolean
-      autofocus?: boolean | string
-      cols?: number
-      disabled?: boolean
-      form?: string
-      maxLength?: number
-      maxlength?: number | string
-      minLength?: number
-      minlength?: number | string
-      name?: string
-      placeholder?: string
-      readOnly?: boolean
-      readonly?: boolean | string
-      required?: boolean
-      rows?: number
-      value?: string | number
-      wrap?: string
-    }
-
-    export interface TdHTMLAttributes<T> extends HTMLAttributes<T> {
-      colSpan?: number
-      colspan?: number
-      headers?: string
-      rowSpan?: number
-    }
-
-    export interface ThHTMLAttributes<T> extends HTMLAttributes<T> {
-      colSpan?: number
-      colspan?: number
-      headers?: string
-      rowSpan?: number
-      rowspan?: number | string
-      scope?: string
-    }
-
-    export interface TimeHTMLAttributes<T> extends HTMLAttributes<T> {
-      dateTime?: string
-    }
-
-    export interface TrackHTMLAttributes<T> extends HTMLAttributes<T> {
-      default?: boolean
-      kind?: string
-      label?: string
-      src?: string
-      srcLang?: string
-      srclang?: string
-    }
-
-    export interface VideoHTMLAttributes<T> extends MediaHTMLAttributes<T> {
-      height?: number | string
-      playsInline?: boolean
-      playsinline?: boolean | string
-      poster?: string
-      width?: number | string
-    }
-
-    export type Child =
-      | string
-      | number
-      | boolean
-      | null
-      | undefined
-      | JSX.Element
-
-    export interface HTMLAttributes<T = HTMLElement> extends DOMAttributes {
-      // Purview specific
-      key?: string | number
-      children?: Child | NestedArray<Child>
-      ignoreChildren?: boolean
-      css?: CSS
-
-      // Standard HTML Attributes
-      accessKey?: string
-      class?: string
-      contentEditable?: boolean | string
-      contenteditable?: boolean | string
-      contextMenu?: string
-      contextmenu?: string
-      dir?: string
-      draggable?: boolean
-      hidden?: boolean
-      id?: string
-      lang?: string
-      slot?: string
-      spellCheck?: boolean
-      spellcheck?: boolean | string
-      style?: string
-      tabIndex?: number
-      tabindex?: number | string
-      title?: string
-
-      // Unknown
-      inputMode?: string
-      inputmode?: string
-      is?: string
-      radioGroup?: string // <command>, <menuitem>
-      radiogroup?: string
-
-      // WAI-ARIA
-      role?: string
-
-      // RDFa Attributes
-      about?: string
-      datatype?: string
-      inlist?: any
-      prefix?: string
-      property?: string
-      resource?: string
-      typeof?: string
-      vocab?: string
-
-      // Non-standard Attributes
-      autoCapitalize?: string
-      autocapitalize?: string
-      autoCorrect?: string
-      autocorrect?: string
-      autoSave?: string
-      autosave?: string
-      color?: string
-      itemProp?: string
-      itemprop?: string
-      itemScope?: boolean
-      itemscope?: boolean
-      itemType?: string
-      itemtype?: string
-      itemID?: string
-      itemid?: string
-      itemRef?: string
-      itemref?: string
-      results?: number
-      security?: string
-      unselectable?: boolean
-    }
-
-    export interface SVGAttributes extends DOMAttributes {
-      // Attributes which are also defined in HTMLAttributes
-      class?: string
-      color?: string
-      height?: number | string
-      id?: string
-      lang?: string
-      max?: number | string
-      media?: string
-      method?: string
-      min?: number | string
-      name?: string
-      style?: string
-      target?: string
-      type?: string
-      width?: number | string
-
-      // Other HTML properties supported by SVG elements in browsers
-      role?: string
-      tabIndex?: number
-
-      // SVG Specific attributes
-      accentHeight?: number | string
-      accumulate?: "none" | "sum"
-      additive?: "replace" | "sum"
-      alignmentBaseline?:
-        | "auto"
-        | "baseline"
-        | "before-edge"
-        | "text-before-edge"
-        | "middle"
-        | "central"
-        | "after-edge"
-        | "text-after-edge"
-        | "ideographic"
-        | "alphabetic"
-        | "hanging"
-        | "mathematical"
-        | "inherit"
-      allowReorder?: "no" | "yes"
-      alphabetic?: number | string
-      amplitude?: number | string
-      arabicForm?: "initial" | "medial" | "terminal" | "isolated"
-      ascent?: number | string
-      attributeName?: string
-      attributeType?: string
-      autoReverse?: number | string
-      azimuth?: number | string
-      baseFrequency?: number | string
-      baselineShift?: number | string
-      baseProfile?: number | string
-      bbox?: number | string
-      begin?: number | string
-      bias?: number | string
-      by?: number | string
-      calcMode?: number | string
-      capHeight?: number | string
-      clip?: number | string
-      clipPath?: string
-      clipPathUnits?: number | string
-      clipRule?: number | string
-      colorInterpolation?: number | string
-      colorInterpolationFilters?: "auto" | "sRGB" | "linearRGB" | "inherit"
-      colorProfile?: number | string
-      colorRendering?: number | string
-      contentScriptType?: number | string
-      contentStyleType?: number | string
-      cursor?: number | string
-      cx?: number | string
-      cy?: number | string
-      d?: string
-      decelerate?: number | string
-      descent?: number | string
-      diffuseConstant?: number | string
-      direction?: number | string
-      display?: number | string
-      divisor?: number | string
-      dominantBaseline?: number | string
-      dur?: number | string
-      dx?: number | string
-      dy?: number | string
-      edgeMode?: number | string
-      elevation?: number | string
-      enableBackground?: number | string
-      end?: number | string
-      exponent?: number | string
-      externalResourcesRequired?: number | string
-      fill?: string
-      fillOpacity?: number | string
-      fillRule?: "nonzero" | "evenodd" | "inherit"
-      filter?: string
-      filterRes?: number | string
-      filterUnits?: number | string
-      floodColor?: number | string
-      floodOpacity?: number | string
-      focusable?: number | string
-      fontFamily?: string
-      fontSize?: number | string
-      fontSizeAdjust?: number | string
-      fontStretch?: number | string
-      fontStyle?: number | string
-      fontVariant?: number | string
-      fontWeight?: number | string
-      format?: number | string
-      from?: number | string
-      fx?: number | string
-      fy?: number | string
-      g1?: number | string
-      g2?: number | string
-      glyphName?: number | string
-      glyphOrientationHorizontal?: number | string
-      glyphOrientationVertical?: number | string
-      glyphRef?: number | string
-      gradientTransform?: string
-      gradientUnits?: string
-      hanging?: number | string
-      horizAdvX?: number | string
-      horizOriginX?: number | string
-      ideographic?: number | string
-      imageRendering?: number | string
-      in2?: number | string
-      in?: string
-      intercept?: number | string
-      k1?: number | string
-      k2?: number | string
-      k3?: number | string
-      k4?: number | string
-      k?: number | string
-      kernelMatrix?: number | string
-      kernelUnitLength?: number | string
-      kerning?: number | string
-      keyPoints?: number | string
-      keySplines?: number | string
-      keyTimes?: number | string
-      lengthAdjust?: number | string
-      letterSpacing?: number | string
-      lightingColor?: number | string
-      limitingConeAngle?: number | string
-      local?: number | string
-      markerEnd?: string
-      markerHeight?: number | string
-      markerMid?: string
-      markerStart?: string
-      markerUnits?: number | string
-      markerWidth?: number | string
-      mask?: string
-      maskContentUnits?: number | string
-      maskUnits?: number | string
-      mathematical?: number | string
-      mode?: number | string
-      numOctaves?: number | string
-      offset?: number | string
-      opacity?: number | string
-      operator?: number | string
-      order?: number | string
-      orient?: number | string
-      orientation?: number | string
-      origin?: number | string
-      overflow?: number | string
-      overlinePosition?: number | string
-      overlineThickness?: number | string
-      paintOrder?: number | string
-      panose1?: number | string
-      pathLength?: number | string
-      patternContentUnits?: string
-      patternTransform?: number | string
-      patternUnits?: string
-      pointerEvents?: number | string
-      points?: string
-      pointsAtX?: number | string
-      pointsAtY?: number | string
-      pointsAtZ?: number | string
-      preserveAlpha?: number | string
-      preserveAspectRatio?: string
-      primitiveUnits?: number | string
-      r?: number | string
-      radius?: number | string
-      refX?: number | string
-      refY?: number | string
-      renderingIntent?: number | string
-      repeatCount?: number | string
-      repeatDur?: number | string
-      requiredExtensions?: number | string
-      requiredFeatures?: number | string
-      restart?: number | string
-      result?: string
-      rotate?: number | string
-      rx?: number | string
-      ry?: number | string
-      scale?: number | string
-      seed?: number | string
-      shapeRendering?: number | string
-      slope?: number | string
-      spacing?: number | string
-      specularConstant?: number | string
-      specularExponent?: number | string
-      speed?: number | string
-      spreadMethod?: string
-      startOffset?: number | string
-      stdDeviation?: number | string
-      stemh?: number | string
-      stemv?: number | string
-      stitchTiles?: number | string
-      stopColor?: string
-      stopOpacity?: number | string
-      strikethroughPosition?: number | string
-      strikethroughThickness?: number | string
-      string?: number | string
-      stroke?: string
-      strokeDasharray?: string | number
-      strokeDashoffset?: string | number
-      strokeLinecap?: "butt" | "round" | "square" | "inherit"
-      strokeLinejoin?: "miter" | "round" | "bevel" | "inherit"
-      strokeMiterlimit?: string
-      strokeOpacity?: number | string
-      strokeWidth?: number | string
-      surfaceScale?: number | string
-      systemLanguage?: number | string
-      tableValues?: number | string
-      targetX?: number | string
-      targetY?: number | string
-      textAnchor?: string
-      textDecoration?: number | string
-      textLength?: number | string
-      textRendering?: number | string
-      to?: number | string
-      transform?: string
-      u1?: number | string
-      u2?: number | string
-      underlinePosition?: number | string
-      underlineThickness?: number | string
-      unicode?: number | string
-      unicodeBidi?: number | string
-      unicodeRange?: number | string
-      unitsPerEm?: number | string
-      vAlphabetic?: number | string
-      values?: string
-      vectorEffect?: number | string
-      version?: string
-      vertAdvY?: number | string
-      vertOriginX?: number | string
-      vertOriginY?: number | string
-      vHanging?: number | string
-      vIdeographic?: number | string
-      viewBox?: string
-      viewTarget?: number | string
-      visibility?: number | string
-      vMathematical?: number | string
-      widths?: number | string
-      wordSpacing?: number | string
-      writingMode?: number | string
-      x1?: number | string
-      x2?: number | string
-      x?: number | string
-      xChannelSelector?: string
-      xHeight?: number | string
-      xlinkActuate?: string
-      xlinkArcrole?: string
-      xlinkHref?: string
-      xlinkRole?: string
-      xlinkShow?: string
-      xlinkTitle?: string
-      xlinkType?: string
-      xmlBase?: string
-      xmlLang?: string
-      xmlns?: string
-      xmlnsXlink?: string
-      xmlSpace?: string
-      y1?: number | string
-      y2?: number | string
-      y?: number | string
-      yChannelSelector?: string
-      z?: number | string
-      zoomAndPan?: string
-    }
-
-    export interface DOMAttributes {
-      // Clipboard Events
-      onCopy?: () => void
-      onCopyCapture?: () => void
-      onCut?: () => void
-      onCutCapture?: () => void
-      onPaste?: () => void
-      onPasteCapture?: () => void
-
-      // Composition Events
-      onCompositionEnd?: () => void
-      onCompositionEndCapture?: () => void
-      onCompositionStart?: () => void
-      onCompositionStartCapture?: () => void
-      onCompositionUpdate?: () => void
-      onCompositionUpdateCapture?: () => void
-
-      // Focus Events
-      onFocus?: () => void
-      onFocusCapture?: () => void
-      onBlur?: () => void
-      onBlurCapture?: () => void
-
-      // Form Events
-      onChange?: (event: InputEvent) => void
-      onChangeCapture?: (event: InputEvent) => void
-      onInput?: (event: InputEvent) => void
-      onInputCapture?: (event: InputEvent) => void
-      onReset?: () => void
-      onResetCapture?: () => void
-      onSubmit?: (event: SubmitEvent) => void
-      onSubmitCapture?: (event: SubmitEvent) => void
-      onInvalid?: () => void
-      onInvalidCapture?: () => void
-
-      // Image Events
-      onLoad?: () => void
-      onLoadCapture?: () => void
-      onError?: () => void // also a Media Event
-      onErrorCapture?: () => void // also a Media Event
-
-      // Keyboard Events
-      onKeyDown?: (event: KeyEvent) => void
-      onKeyDownCapture?: (event: KeyEvent) => void
-      onKeyPress?: (event: KeyEvent) => void
-      onKeyPressCapture?: (event: KeyEvent) => void
-      onKeyUp?: (event: KeyEvent) => void
-      onKeyUpCapture?: (event: KeyEvent) => void
-
-      // MouseEvents
-      onAuxClick?: () => void
-      onClick?: () => void
-      onClickCapture?: () => void
-      onContextMenu?: () => void
-      onContextMenuCapture?: () => void
-      onDblClick?: () => void
-      onDblClickCapture?: () => void
-      onDrag?: () => void
-      onDragCapture?: () => void
-      onDragEnd?: () => void
-      onDragEndCapture?: () => void
-      onDragEnter?: () => void
-      onDragEnterCapture?: () => void
-      onDragExit?: () => void
-      onDragExitCapture?: () => void
-      onDragLeave?: () => void
-      onDragLeaveCapture?: () => void
-      onDragOver?: () => void
-      onDragOverCapture?: () => void
-      onDragStart?: () => void
-      onDragStartCapture?: () => void
-      onDrop?: () => void
-      onDropCapture?: () => void
-      onMouseDown?: () => void
-      onMouseDownCapture?: () => void
-      onMouseEnter?: () => void
-      onMouseLeave?: () => void
-      onMouseMove?: () => void
-      onMouseMoveCapture?: () => void
-      onMouseOut?: () => void
-      onMouseOutCapture?: () => void
-      onMouseOver?: () => void
-      onMouseOverCapture?: () => void
-      onMouseUp?: () => void
-      onMouseUpCapture?: () => void
-
-      // Touch Events
-      onTouchCancel?: () => void
-      onTouchCancelCapture?: () => void
-      onTouchEnd?: () => void
-      onTouchEndCapture?: () => void
-      onTouchMove?: () => void
-      onTouchMoveCapture?: () => void
-      onTouchStart?: () => void
-      onTouchStartCapture?: () => void
-
-      // UI Events
-      onScroll?: () => void
-      onScrollCapture?: () => void
-
-      // Wheel Events
-      onWheel?: () => void
-      onWheelCapture?: () => void
-
-      // Animation Events
-      onAnimationStart?: () => void
-      onAnimationStartCapture?: () => void
-      onAnimationEnd?: () => void
-      onAnimationEndCapture?: () => void
-      onAnimationIteration?: () => void
-      onAnimationIterationCapture?: () => void
-
-      // Transition Events
-      onTransitionEnd?: () => void
-      onTransitionEndCapture?: () => void
-    }
+}
+
+export namespace JSXInternal {
+  export interface Element<T = HTMLAttributes> {
+    nodeName: string | ComponentConstructor<any, any>
+    attributes: T
+    children: Child | NestedArray<Child>
+  }
+  export interface ComponentElement<T = HTMLAttributes> extends Element<T> {
+    nodeName: ComponentConstructor<any, any>
+  }
+  export interface NormalElement<T = HTMLAttributes> extends Element<T> {
+    nodeName: string
+  }
+
+  export interface ElementClass extends Component<any, any> {}
+  export interface ElementAttributesProperty {
+    props: {}
+  }
+  export interface ElementChildrenAttribute {
+    children: {}
+  }
+
+  // Everything below is taken from:
+  // https://github.com/ionic-team/stencil/blob/master/src/declarations/jsx.ts
+  export interface IntrinsicElements {
+    // HTML
+    a: AnchorHTMLAttributes
+    abbr: HTMLAttributes
+    address: HTMLAttributes
+    area: AreaHTMLAttributes
+    article: HTMLAttributes
+    aside: HTMLAttributes
+    audio: AudioHTMLAttributes
+    b: HTMLAttributes
+    base: BaseHTMLAttributes
+    bdi: HTMLAttributes
+    bdo: HTMLAttributes
+    big: HTMLAttributes
+    blockquote: BlockquoteHTMLAttributes
+    body: HTMLAttributes
+    br: HTMLAttributes
+    button: ButtonHTMLAttributes
+    canvas: CanvasHTMLAttributes
+    caption: HTMLAttributes
+    cite: HTMLAttributes
+    code: HTMLAttributes
+    col: ColHTMLAttributes
+    colgroup: ColgroupHTMLAttributes
+    data: HTMLAttributes
+    datalist: HTMLAttributes
+    dd: HTMLAttributes
+    del: DelHTMLAttributes
+    details: DetailsHTMLAttributes
+    dfn: HTMLAttributes
+    dialog: DialogHTMLAttributes
+    div: HTMLAttributes
+    dl: HTMLAttributes
+    dt: HTMLAttributes
+    em: HTMLAttributes
+    embed: EmbedHTMLAttributes
+    fieldset: FieldsetHTMLAttributes
+    figcaption: HTMLAttributes
+    figure: HTMLAttributes
+    footer: HTMLAttributes
+    form: FormHTMLAttributes
+    h1: HTMLAttributes
+    h2: HTMLAttributes
+    h3: HTMLAttributes
+    h4: HTMLAttributes
+    h5: HTMLAttributes
+    h6: HTMLAttributes
+    head: HTMLAttributes
+    header: HTMLAttributes
+    hgroup: HTMLAttributes
+    hr: HTMLAttributes
+    html: HTMLAttributes
+    i: HTMLAttributes
+    iframe: IframeHTMLAttributes
+    img: ImgHTMLAttributes
+    input:
+      | CheckboxInputHTMLAttributes
+      | NumberInputHTMLAttributes
+      | TextInputHTMLAttributes
+    ins: InsHTMLAttributes
+    kbd: HTMLAttributes
+    keygen: KeygenHTMLAttributes
+    label: LabelHTMLAttributes
+    legend: HTMLAttributes
+    li: LiHTMLAttributes
+    link: LinkHTMLAttributes
+    main: HTMLAttributes
+    map: MapHTMLAttributes
+    mark: HTMLAttributes
+    menu: MenuHTMLAttributes
+    menuitem: HTMLAttributes
+    meta: MetaHTMLAttributes
+    meter: MeterHTMLAttributes
+    nav: HTMLAttributes
+    noscript: HTMLAttributes
+    object: ObjectHTMLAttributes
+    ol: OlHTMLAttributes
+    optgroup: OptgroupHTMLAttributes
+    option: OptionHTMLAttributes
+    output: OutputHTMLAttributes
+    p: HTMLAttributes
+    param: ParamHTMLAttributes
+    picture: HTMLAttributes
+    pre: HTMLAttributes
+    progress: ProgressHTMLAttributes
+    q: QuoteHTMLAttributes
+    rp: HTMLAttributes
+    rt: HTMLAttributes
+    ruby: HTMLAttributes
+    s: HTMLAttributes
+    samp: HTMLAttributes
+    script: ScriptHTMLAttributes
+    section: HTMLAttributes
+    select: MultiSelectHTMLAttributes | SingleSelectHTMLAttributes
+    small: HTMLAttributes
+    source: SourceHTMLAttributes
+    span: HTMLAttributes
+    strong: HTMLAttributes
+    style: StyleHTMLAttributes
+    sub: HTMLAttributes
+    summary: HTMLAttributes
+    sup: HTMLAttributes
+    table: TableHTMLAttributes
+    tbody: HTMLAttributes
+    td: TdHTMLAttributes
+    textarea: TextareaHTMLAttributes
+    tfoot: HTMLAttributes
+    th: ThHTMLAttributes
+    thead: HTMLAttributes
+    time: TimeHTMLAttributes
+    title: HTMLAttributes
+    tr: HTMLAttributes
+    track: TrackHTMLAttributes
+    u: HTMLAttributes
+    ul: HTMLAttributes
+    var: HTMLAttributes
+    video: VideoHTMLAttributes
+    wbr: HTMLAttributes
+  }
+
+  export interface AnchorHTMLAttributes extends HTMLAttributes {
+    download?: any
+    href?: string
+    hrefLang?: string
+    hreflang?: string
+    media?: string
+    rel?: string
+    target?: string
+  }
+
+  // tslint:disable-next-line
+  export interface AudioHTMLAttributes extends MediaHTMLAttributes {}
+
+  export interface AreaHTMLAttributes extends HTMLAttributes {
+    alt?: string
+    coords?: string
+    download?: any
+    href?: string
+    hrefLang?: string
+    hreflang?: string
+    media?: string
+    rel?: string
+    shape?: string
+    target?: string
+  }
+
+  export interface BaseHTMLAttributes extends HTMLAttributes {
+    href?: string
+    target?: string
+  }
+
+  export interface BlockquoteHTMLAttributes extends HTMLAttributes {
+    cite?: string
+  }
+
+  export interface ButtonHTMLAttributes extends HTMLAttributes {
+    autoFocus?: boolean
+    disabled?: boolean
+    form?: string
+    formAction?: string
+    formaction?: string
+    formEncType?: string
+    formenctype?: string
+    formMethod?: string
+    formmethod?: string
+    formNoValidate?: boolean
+    formnovalidate?: boolean
+    formTarget?: string
+    formtarget?: string
+    name?: string
+    type?: string
+    value?: string | number
+  }
+
+  export interface CanvasHTMLAttributes extends HTMLAttributes {
+    height?: number | string
+    width?: number | string
+  }
+
+  export interface ColHTMLAttributes extends HTMLAttributes {
+    span?: number
+  }
+
+  export interface ColgroupHTMLAttributes extends HTMLAttributes {
+    span?: number
+  }
+
+  export interface DetailsHTMLAttributes extends HTMLAttributes {
+    open?: boolean
+  }
+
+  export interface DelHTMLAttributes extends HTMLAttributes {
+    cite?: string
+    dateTime?: string
+    datetime?: string
+  }
+
+  export interface DialogHTMLAttributes extends HTMLAttributes {
+    open?: boolean
+    returnValue?: string
+  }
+
+  export interface EmbedHTMLAttributes extends HTMLAttributes {
+    height?: number | string
+    src?: string
+    type?: string
+    width?: number | string
+  }
+
+  export interface FieldsetHTMLAttributes extends HTMLAttributes {
+    disabled?: boolean
+    form?: string
+    name?: string
+  }
+
+  export interface FormHTMLAttributes extends HTMLAttributes {
+    acceptCharset?: string
+    acceptcharset?: string
+    action?: string
+    autoComplete?: string
+    autocomplete?: string
+    encType?: string
+    enctype?: string
+    method?: string
+    name?: string
+    noValidate?: boolean
+    novalidate?: boolean | string
+    target?: string
+  }
+
+  export interface HtmlHTMLAttributes extends HTMLAttributes {
+    manifest?: string
+  }
+
+  export interface IframeHTMLAttributes extends HTMLAttributes {
+    allowFullScreen?: boolean
+    allowfullScreen?: string | boolean
+    allowTransparency?: boolean
+    allowtransparency?: string | boolean
+    frameBorder?: number | string
+    frameborder?: number | string
+    height?: number | string
+    marginHeight?: number
+    marginheight?: string | number
+    marginWidth?: number
+    marginwidth?: string | number
+    name?: string
+    sandbox?: string
+    scrolling?: string
+    seamless?: boolean
+    src?: string
+    srcDoc?: string
+    srcdoc?: string
+    width?: number | string
+  }
+
+  export interface ImgHTMLAttributes extends HTMLAttributes {
+    alt?: string
+    decoding?: "async" | "auto" | "sync"
+    height?: number | string
+    sizes?: string
+    src?: string
+    srcSet?: string
+    srcset?: string
+    useMap?: string
+    usemap?: string
+    width?: number | string
+  }
+
+  export interface InsHTMLAttributes extends HTMLAttributes {
+    cite?: string
+    dateTime?: string
+    datetime?: string
+  }
+
+  export interface CheckboxInputHTMLAttributes
+    extends Omit<InputHTMLAttributes, "onChange" | "onInput"> {
+    type: "checkbox"
+    onChange?: (event: ChangeEvent<boolean>) => void
+    onInput?: (event: InputEvent<boolean>) => void
+  }
+
+  export interface NumberInputHTMLAttributes
+    extends Omit<InputHTMLAttributes, "onChange" | "onInput"> {
+    type: "number"
+    onChange?: (event: ChangeEvent<number>) => void
+    onInput?: (event: InputEvent<number>) => void
+  }
+
+  export interface TextInputHTMLAttributes
+    extends Omit<InputHTMLAttributes, "onChange" | "onInput"> {
+    type?: Exclude<InputType, "checkbox" | "number">
+    onChange?: (event: ChangeEvent<string>) => void
+    onInput?: (event: InputEvent<string>) => void
+  }
+
+  export type InputType =
+    | "button"
+    | "checkbox"
+    | "color"
+    | "date"
+    | "datetime"
+    | "datetime-local"
+    | "email"
+    | "file"
+    | "hidden"
+    | "image"
+    | "month"
+    | "number"
+    | "password"
+    | "radio"
+    | "range"
+    | "reset"
+    | "search"
+    | "submit"
+    | "tel"
+    | "text"
+    | "time"
+    | "url"
+    | "week"
+
+  export interface InputHTMLAttributes extends HTMLAttributes {
+    // Purview specific
+    defaultValue?: string | number
+    defaultChecked?: boolean
+
+    // Standard HTML Attributes
+    accept?: string
+    alt?: string
+    autoComplete?: string
+    autocomplete?: string
+    autoFocus?: boolean
+    autofocus?: boolean | string
+    capture?: string // https://www.w3.org/TR/html-media-capture/#the-capture-attribute
+    checked?: boolean
+    crossOrigin?: string
+    crossorigin?: string
+    disabled?: boolean
+    form?: string
+    formAction?: string
+    formaction?: string
+    formEncType?: string
+    formenctype?: string
+    formMethod?: string
+    formmethod?: string
+    formNoValidate?: boolean
+    formnovalidate?: boolean
+    formTarget?: string
+    formtarget?: string
+    height?: number | string
+    list?: string
+    max?: number | string
+    maxLength?: number
+    maxlength?: number | string
+    min?: number | string
+    minLength?: number
+    minlength?: number | string
+    multiple?: boolean
+    name?: string
+    pattern?: string
+    placeholder?: string
+    readOnly?: boolean
+    readonly?: boolean | string
+    required?: boolean
+    size?: number
+    src?: string
+    step?: number | string
+    type?: InputType
+    value?: string | number
+    width?: number | string
+  }
+
+  export interface KeygenHTMLAttributes extends HTMLAttributes {
+    autoFocus?: boolean
+    autofocus?: boolean | string
+    challenge?: string
+    disabled?: boolean
+    form?: string
+    keyType?: string
+    keytype?: string
+    keyParams?: string
+    keyparams?: string
+    name?: string
+  }
+
+  export interface LabelHTMLAttributes extends HTMLAttributes {
+    form?: string
+    htmlFor?: string
+    htmlfor?: string
+  }
+
+  export interface LiHTMLAttributes extends HTMLAttributes {
+    value?: string | number
+  }
+
+  export interface LinkHTMLAttributes extends HTMLAttributes {
+    href?: string
+    hrefLang?: string
+    hreflang?: string
+    integrity?: string
+    media?: string
+    rel?: string
+    sizes?: string
+    type?: string
+  }
+
+  export interface MapHTMLAttributes extends HTMLAttributes {
+    name?: string
+  }
+
+  export interface MenuHTMLAttributes extends HTMLAttributes {
+    type?: string
+  }
+
+  export interface MediaHTMLAttributes extends HTMLAttributes {
+    autoPlay?: boolean
+    autoplay?: boolean | string
+    controls?: boolean
+    crossOrigin?: string
+    crossorigin?: string
+    loop?: boolean
+    mediaGroup?: string
+    mediagroup?: string
+    muted?: boolean
+    preload?: string
+    src?: string
+  }
+
+  export interface MetaHTMLAttributes extends HTMLAttributes {
+    charSet?: string
+    charset?: string
+    content?: string
+    httpEquiv?: string
+    httpequiv?: string
+    name?: string
+  }
+
+  export interface MeterHTMLAttributes extends HTMLAttributes {
+    form?: string
+    high?: number
+    low?: number
+    max?: number | string
+    min?: number | string
+    optimum?: number
+    value?: string | number
+  }
+
+  export interface QuoteHTMLAttributes extends HTMLAttributes {
+    cite?: string
+  }
+
+  export interface ObjectHTMLAttributes extends HTMLAttributes {
+    classID?: string
+    classid?: string
+    data?: string
+    form?: string
+    height?: number | string
+    name?: string
+    type?: string
+    useMap?: string
+    usemap?: string
+    width?: number | string
+    wmode?: string
+  }
+
+  export interface OlHTMLAttributes extends HTMLAttributes {
+    reversed?: boolean
+    start?: number
+  }
+
+  export interface OptgroupHTMLAttributes extends HTMLAttributes {
+    disabled?: boolean
+    label?: string
+  }
+
+  export interface OptionHTMLAttributes extends HTMLAttributes {
+    // Purview specific
+    defaultSelected?: boolean
+
+    // Standard HTML attributes
+    disabled?: boolean
+    label?: string
+    selected?: boolean
+    value?: string | number
+  }
+
+  export interface OutputHTMLAttributes extends HTMLAttributes {
+    form?: string
+    htmlFor?: string
+    htmlfor?: string
+    name?: string
+  }
+
+  export interface ParamHTMLAttributes extends HTMLAttributes {
+    name?: string
+    value?: string | number
+  }
+
+  export interface ProgressHTMLAttributes extends HTMLAttributes {
+    max?: number | string
+    value?: string | number
+  }
+
+  export interface ScriptHTMLAttributes extends HTMLAttributes {
+    async?: boolean
+    charSet?: string
+    charset?: string
+    crossOrigin?: string
+    crossorigin?: string
+    defer?: boolean
+    integrity?: string
+    nonce?: string
+    src?: string
+    type?: string
+  }
+
+  export interface MultiSelectHTMLAttributes
+    extends Omit<SelectHTMLAttributes, "onChange" | "onInput"> {
+    multiple: true
+    onChange?: (event: ChangeEvent<string[]>) => void
+    onInput?: (event: InputEvent<string[]>) => void
+  }
+
+  export interface SingleSelectHTMLAttributes
+    extends Omit<SelectHTMLAttributes, "onChange" | "onInput"> {
+    multiple?: false
+    onChange?: (event: ChangeEvent<string>) => void
+    onInput?: (event: InputEvent<string>) => void
+  }
+
+  export interface SelectHTMLAttributes extends HTMLAttributes {
+    autoFocus?: boolean
+    autoComplete?: string
+    autocomplete?: string
+    disabled?: boolean
+    form?: string
+    multiple?: boolean
+    name?: string
+    required?: boolean
+    size?: number
+  }
+
+  export interface SourceHTMLAttributes extends HTMLAttributes {
+    media?: string
+    sizes?: string
+    src?: string
+    srcSet?: string
+    type?: string
+  }
+
+  export interface StyleHTMLAttributes extends HTMLAttributes {
+    media?: string
+    nonce?: string
+    scoped?: boolean
+    type?: string
+  }
+
+  export interface TableHTMLAttributes extends HTMLAttributes {
+    cellPadding?: number | string
+    cellpadding?: number | string
+    cellSpacing?: number | string
+    cellspacing?: number | string
+    summary?: string
+  }
+
+  export interface TextareaHTMLAttributes extends HTMLAttributes {
+    // Purview specific
+    defaultValue?: string | number
+
+    // Standard HTML attributes
+    autoFocus?: boolean
+    autofocus?: boolean | string
+    cols?: number
+    disabled?: boolean
+    form?: string
+    maxLength?: number
+    maxlength?: number | string
+    minLength?: number
+    minlength?: number | string
+    name?: string
+    placeholder?: string
+    readOnly?: boolean
+    readonly?: boolean | string
+    required?: boolean
+    rows?: number
+    value?: string | number
+    wrap?: string
+  }
+
+  export interface TdHTMLAttributes extends HTMLAttributes {
+    colSpan?: number
+    colspan?: number
+    headers?: string
+    rowSpan?: number
+  }
+
+  export interface ThHTMLAttributes extends HTMLAttributes {
+    colSpan?: number
+    colspan?: number
+    headers?: string
+    rowSpan?: number
+    rowspan?: number | string
+    scope?: string
+  }
+
+  export interface TimeHTMLAttributes extends HTMLAttributes {
+    dateTime?: string
+  }
+
+  export interface TrackHTMLAttributes extends HTMLAttributes {
+    default?: boolean
+    kind?: string
+    label?: string
+    src?: string
+    srcLang?: string
+    srclang?: string
+  }
+
+  export interface VideoHTMLAttributes extends MediaHTMLAttributes {
+    height?: number | string
+    playsInline?: boolean
+    playsinline?: boolean | string
+    poster?: string
+    width?: number | string
+  }
+
+  export type Child =
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | JSXInternal.Element
+
+  export interface HTMLAttributes extends DOMAttributes {
+    // Purview specific
+    key?: string | number
+    children?: Child | NestedArray<Child>
+    ignoreChildren?: boolean
+    css?: CSS
+
+    // Standard HTML Attributes
+    accessKey?: string
+    class?: string
+    contentEditable?: boolean | string
+    contenteditable?: boolean | string
+    contextMenu?: string
+    contextmenu?: string
+    dir?: string
+    draggable?: boolean
+    hidden?: boolean
+    id?: string
+    lang?: string
+    slot?: string
+    spellCheck?: boolean
+    spellcheck?: boolean | string
+    style?: string
+    tabIndex?: number
+    tabindex?: number | string
+    title?: string
+
+    // Unknown
+    inputMode?: string
+    inputmode?: string
+    is?: string
+    radioGroup?: string // <command>, <menuitem>
+    radiogroup?: string
+
+    // WAI-ARIA
+    role?: string
+
+    // RDFa Attributes
+    about?: string
+    datatype?: string
+    inlist?: any
+    prefix?: string
+    property?: string
+    resource?: string
+    typeof?: string
+    vocab?: string
+
+    // Non-standard Attributes
+    autoCapitalize?: string
+    autocapitalize?: string
+    autoCorrect?: string
+    autocorrect?: string
+    autoSave?: string
+    autosave?: string
+    color?: string
+    itemProp?: string
+    itemprop?: string
+    itemScope?: boolean
+    itemscope?: boolean
+    itemType?: string
+    itemtype?: string
+    itemID?: string
+    itemid?: string
+    itemRef?: string
+    itemref?: string
+    results?: number
+    security?: string
+    unselectable?: boolean
+  }
+
+  export interface SVGAttributes extends DOMAttributes {
+    // Attributes which are also defined in HTMLAttributes
+    class?: string
+    color?: string
+    height?: number | string
+    id?: string
+    lang?: string
+    max?: number | string
+    media?: string
+    method?: string
+    min?: number | string
+    name?: string
+    style?: string
+    target?: string
+    type?: string
+    width?: number | string
+
+    // Other HTML properties supported by SVG elements in browsers
+    role?: string
+    tabIndex?: number
+
+    // SVG Specific attributes
+    accentHeight?: number | string
+    accumulate?: "none" | "sum"
+    additive?: "replace" | "sum"
+    alignmentBaseline?:
+      | "auto"
+      | "baseline"
+      | "before-edge"
+      | "text-before-edge"
+      | "middle"
+      | "central"
+      | "after-edge"
+      | "text-after-edge"
+      | "ideographic"
+      | "alphabetic"
+      | "hanging"
+      | "mathematical"
+      | "inherit"
+    allowReorder?: "no" | "yes"
+    alphabetic?: number | string
+    amplitude?: number | string
+    arabicForm?: "initial" | "medial" | "terminal" | "isolated"
+    ascent?: number | string
+    attributeName?: string
+    attributeType?: string
+    autoReverse?: number | string
+    azimuth?: number | string
+    baseFrequency?: number | string
+    baselineShift?: number | string
+    baseProfile?: number | string
+    bbox?: number | string
+    begin?: number | string
+    bias?: number | string
+    by?: number | string
+    calcMode?: number | string
+    capHeight?: number | string
+    clip?: number | string
+    clipPath?: string
+    clipPathUnits?: number | string
+    clipRule?: number | string
+    colorInterpolation?: number | string
+    colorInterpolationFilters?: "auto" | "sRGB" | "linearRGB" | "inherit"
+    colorProfile?: number | string
+    colorRendering?: number | string
+    contentScriptType?: number | string
+    contentStyleType?: number | string
+    cursor?: number | string
+    cx?: number | string
+    cy?: number | string
+    d?: string
+    decelerate?: number | string
+    descent?: number | string
+    diffuseConstant?: number | string
+    direction?: number | string
+    display?: number | string
+    divisor?: number | string
+    dominantBaseline?: number | string
+    dur?: number | string
+    dx?: number | string
+    dy?: number | string
+    edgeMode?: number | string
+    elevation?: number | string
+    enableBackground?: number | string
+    end?: number | string
+    exponent?: number | string
+    externalResourcesRequired?: number | string
+    fill?: string
+    fillOpacity?: number | string
+    fillRule?: "nonzero" | "evenodd" | "inherit"
+    filter?: string
+    filterRes?: number | string
+    filterUnits?: number | string
+    floodColor?: number | string
+    floodOpacity?: number | string
+    focusable?: number | string
+    fontFamily?: string
+    fontSize?: number | string
+    fontSizeAdjust?: number | string
+    fontStretch?: number | string
+    fontStyle?: number | string
+    fontVariant?: number | string
+    fontWeight?: number | string
+    format?: number | string
+    from?: number | string
+    fx?: number | string
+    fy?: number | string
+    g1?: number | string
+    g2?: number | string
+    glyphName?: number | string
+    glyphOrientationHorizontal?: number | string
+    glyphOrientationVertical?: number | string
+    glyphRef?: number | string
+    gradientTransform?: string
+    gradientUnits?: string
+    hanging?: number | string
+    horizAdvX?: number | string
+    horizOriginX?: number | string
+    ideographic?: number | string
+    imageRendering?: number | string
+    in2?: number | string
+    in?: string
+    intercept?: number | string
+    k1?: number | string
+    k2?: number | string
+    k3?: number | string
+    k4?: number | string
+    k?: number | string
+    kernelMatrix?: number | string
+    kernelUnitLength?: number | string
+    kerning?: number | string
+    keyPoints?: number | string
+    keySplines?: number | string
+    keyTimes?: number | string
+    lengthAdjust?: number | string
+    letterSpacing?: number | string
+    lightingColor?: number | string
+    limitingConeAngle?: number | string
+    local?: number | string
+    markerEnd?: string
+    markerHeight?: number | string
+    markerMid?: string
+    markerStart?: string
+    markerUnits?: number | string
+    markerWidth?: number | string
+    mask?: string
+    maskContentUnits?: number | string
+    maskUnits?: number | string
+    mathematical?: number | string
+    mode?: number | string
+    numOctaves?: number | string
+    offset?: number | string
+    opacity?: number | string
+    operator?: number | string
+    order?: number | string
+    orient?: number | string
+    orientation?: number | string
+    origin?: number | string
+    overflow?: number | string
+    overlinePosition?: number | string
+    overlineThickness?: number | string
+    paintOrder?: number | string
+    panose1?: number | string
+    pathLength?: number | string
+    patternContentUnits?: string
+    patternTransform?: number | string
+    patternUnits?: string
+    pointerEvents?: number | string
+    points?: string
+    pointsAtX?: number | string
+    pointsAtY?: number | string
+    pointsAtZ?: number | string
+    preserveAlpha?: number | string
+    preserveAspectRatio?: string
+    primitiveUnits?: number | string
+    r?: number | string
+    radius?: number | string
+    refX?: number | string
+    refY?: number | string
+    renderingIntent?: number | string
+    repeatCount?: number | string
+    repeatDur?: number | string
+    requiredExtensions?: number | string
+    requiredFeatures?: number | string
+    restart?: number | string
+    result?: string
+    rotate?: number | string
+    rx?: number | string
+    ry?: number | string
+    scale?: number | string
+    seed?: number | string
+    shapeRendering?: number | string
+    slope?: number | string
+    spacing?: number | string
+    specularConstant?: number | string
+    specularExponent?: number | string
+    speed?: number | string
+    spreadMethod?: string
+    startOffset?: number | string
+    stdDeviation?: number | string
+    stemh?: number | string
+    stemv?: number | string
+    stitchTiles?: number | string
+    stopColor?: string
+    stopOpacity?: number | string
+    strikethroughPosition?: number | string
+    strikethroughThickness?: number | string
+    string?: number | string
+    stroke?: string
+    strokeDasharray?: string | number
+    strokeDashoffset?: string | number
+    strokeLinecap?: "butt" | "round" | "square" | "inherit"
+    strokeLinejoin?: "miter" | "round" | "bevel" | "inherit"
+    strokeMiterlimit?: string
+    strokeOpacity?: number | string
+    strokeWidth?: number | string
+    surfaceScale?: number | string
+    systemLanguage?: number | string
+    tableValues?: number | string
+    targetX?: number | string
+    targetY?: number | string
+    textAnchor?: string
+    textDecoration?: number | string
+    textLength?: number | string
+    textRendering?: number | string
+    to?: number | string
+    transform?: string
+    u1?: number | string
+    u2?: number | string
+    underlinePosition?: number | string
+    underlineThickness?: number | string
+    unicode?: number | string
+    unicodeBidi?: number | string
+    unicodeRange?: number | string
+    unitsPerEm?: number | string
+    vAlphabetic?: number | string
+    values?: string
+    vectorEffect?: number | string
+    version?: string
+    vertAdvY?: number | string
+    vertOriginX?: number | string
+    vertOriginY?: number | string
+    vHanging?: number | string
+    vIdeographic?: number | string
+    viewBox?: string
+    viewTarget?: number | string
+    visibility?: number | string
+    vMathematical?: number | string
+    widths?: number | string
+    wordSpacing?: number | string
+    writingMode?: number | string
+    x1?: number | string
+    x2?: number | string
+    x?: number | string
+    xChannelSelector?: string
+    xHeight?: number | string
+    xlinkActuate?: string
+    xlinkArcrole?: string
+    xlinkHref?: string
+    xlinkRole?: string
+    xlinkShow?: string
+    xlinkTitle?: string
+    xlinkType?: string
+    xmlBase?: string
+    xmlLang?: string
+    xmlns?: string
+    xmlnsXlink?: string
+    xmlSpace?: string
+    y1?: number | string
+    y2?: number | string
+    y?: number | string
+    yChannelSelector?: string
+    z?: number | string
+    zoomAndPan?: string
+  }
+
+  export interface DOMAttributes {
+    // Clipboard Events
+    onCopy?: () => void
+    onCopyCapture?: () => void
+    onCut?: () => void
+    onCutCapture?: () => void
+    onPaste?: () => void
+    onPasteCapture?: () => void
+
+    // Composition Events
+    onCompositionEnd?: () => void
+    onCompositionEndCapture?: () => void
+    onCompositionStart?: () => void
+    onCompositionStartCapture?: () => void
+    onCompositionUpdate?: () => void
+    onCompositionUpdateCapture?: () => void
+
+    // Focus Events
+    onFocus?: () => void
+    onFocusCapture?: () => void
+    onBlur?: () => void
+    onBlurCapture?: () => void
+
+    // Form Events
+    onChange?: (event: InputEvent) => void
+    onChangeCapture?: (event: InputEvent) => void
+    onInput?: (event: InputEvent) => void
+    onInputCapture?: (event: InputEvent) => void
+    onReset?: () => void
+    onResetCapture?: () => void
+    onSubmit?: (event: SubmitEvent) => void
+    onSubmitCapture?: (event: SubmitEvent) => void
+    onInvalid?: () => void
+    onInvalidCapture?: () => void
+
+    // Image Events
+    onLoad?: () => void
+    onLoadCapture?: () => void
+    onError?: () => void // also a Media Event
+    onErrorCapture?: () => void // also a Media Event
+
+    // Keyboard Events
+    onKeyDown?: (event: KeyEvent) => void
+    onKeyDownCapture?: (event: KeyEvent) => void
+    onKeyPress?: (event: KeyEvent) => void
+    onKeyPressCapture?: (event: KeyEvent) => void
+    onKeyUp?: (event: KeyEvent) => void
+    onKeyUpCapture?: (event: KeyEvent) => void
+
+    // MouseEvents
+    onAuxClick?: () => void
+    onClick?: () => void
+    onClickCapture?: () => void
+    onContextMenu?: () => void
+    onContextMenuCapture?: () => void
+    onDblClick?: () => void
+    onDblClickCapture?: () => void
+    onDrag?: () => void
+    onDragCapture?: () => void
+    onDragEnd?: () => void
+    onDragEndCapture?: () => void
+    onDragEnter?: () => void
+    onDragEnterCapture?: () => void
+    onDragExit?: () => void
+    onDragExitCapture?: () => void
+    onDragLeave?: () => void
+    onDragLeaveCapture?: () => void
+    onDragOver?: () => void
+    onDragOverCapture?: () => void
+    onDragStart?: () => void
+    onDragStartCapture?: () => void
+    onDrop?: () => void
+    onDropCapture?: () => void
+    onMouseDown?: () => void
+    onMouseDownCapture?: () => void
+    onMouseEnter?: () => void
+    onMouseLeave?: () => void
+    onMouseMove?: () => void
+    onMouseMoveCapture?: () => void
+    onMouseOut?: () => void
+    onMouseOutCapture?: () => void
+    onMouseOver?: () => void
+    onMouseOverCapture?: () => void
+    onMouseUp?: () => void
+    onMouseUpCapture?: () => void
+
+    // Touch Events
+    onTouchCancel?: () => void
+    onTouchCancelCapture?: () => void
+    onTouchEnd?: () => void
+    onTouchEndCapture?: () => void
+    onTouchMove?: () => void
+    onTouchMoveCapture?: () => void
+    onTouchStart?: () => void
+    onTouchStartCapture?: () => void
+
+    // UI Events
+    onScroll?: () => void
+    onScrollCapture?: () => void
+
+    // Wheel Events
+    onWheel?: () => void
+    onWheelCapture?: () => void
+
+    // Animation Events
+    onAnimationStart?: () => void
+    onAnimationStartCapture?: () => void
+    onAnimationEnd?: () => void
+    onAnimationEndCapture?: () => void
+    onAnimationIteration?: () => void
+    onAnimationIterationCapture?: () => void
+
+    // Transition Events
+    onTransitionEnd?: () => void
+    onTransitionEndCapture?: () => void
   }
 }

--- a/src/types/jsx.ts
+++ b/src/types/jsx.ts
@@ -1,11 +1,9 @@
 import Component, { ComponentConstructor } from "../component"
 import { InputEvent, SubmitEvent, KeyEvent, ChangeEvent } from "./ws"
 import { CSS } from "../css"
+import { NestedArray } from "./utility"
 
 /* tslint:disable no-namespace */
-declare global {
-  interface NestedArray<T> extends Array<NestedArray<T> | T> {}
-}
 
 export namespace JSX {
   export interface Element<T = HTMLAttributes> {

--- a/src/types/jsx.ts
+++ b/src/types/jsx.ts
@@ -1,7 +1,7 @@
 import Component, { ComponentConstructor } from "../component"
 import { InputEvent, SubmitEvent, KeyEvent, ChangeEvent } from "./ws"
 import { CSS } from "../css"
-import { NestedArray } from "./utility"
+import { NestedArray } from "../helpers"
 
 /* tslint:disable no-namespace */
 

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -1,0 +1,1 @@
+export interface NestedArray<T> extends Array<NestedArray<T> | T> {}

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -1,1 +1,0 @@
-export interface NestedArray<T> extends Array<NestedArray<T> | T> {}

--- a/test/client_test.tsx
+++ b/test/client_test.tsx
@@ -1,5 +1,6 @@
 import { JSDOM } from "jsdom"
 import * as WebSocket from "ws"
+import { JSX } from "../src/purview"
 
 const {
   window,

--- a/test/helpers_test.ts
+++ b/test/helpers_test.ts
@@ -1,3 +1,4 @@
+import { NestedArray } from "../src/purview"
 import { mapNested } from "../src/helpers"
 
 test("mapNested", () => {

--- a/test/morph_test.tsx
+++ b/test/morph_test.tsx
@@ -1,4 +1,5 @@
 import { JSDOM } from "jsdom"
+import { JSX } from "../src/purview"
 
 const { document, HTMLElement } = new JSDOM().window
 Object.assign(global, { document, HTMLElement })
@@ -51,16 +52,16 @@ test("morph text input value undefined", () => {
 
 test("morph option selected", async () => {
   const select = populate(
-    <select>
-      <optgroup>
-        <option>Foo</option>
-      </optgroup>
-      <option selected>Bar</option>
-      <option>Baz</option>
-    </select>,
-  ) as HTMLInputElement
+      <select>
+        <optgroup>
+          <option>Foo</option>
+        </optgroup>
+        <option selected>Bar</option>
+        <option>Baz</option>
+      </select>,
+    ) as HTMLInputElement
 
-  // Simulate user selecting an option.
+    // Simulate user selecting an option.
   ;(select.children[0].children[0] as HTMLOptionElement).selected = true
   ;(select.children[1] as HTMLOptionElement).selected = false
   expect(document.querySelector("select")!.value).toBe("Foo")
@@ -82,13 +83,13 @@ test("morph option selected", async () => {
 
 test("morph select multiple", async () => {
   const select = populate(
-    <select multiple>
-      <option>Foo</option>
-      <option>Bar</option>
-    </select>,
-  ) as HTMLSelectElement
+      <select multiple>
+        <option>Foo</option>
+        <option>Bar</option>
+      </select>,
+    ) as HTMLSelectElement
 
-  // Simulate user selecting multiple options.
+    // Simulate user selecting multiple options.
   ;(select.children[0] as HTMLOptionElement).selected = true
   ;(select.children[1] as HTMLOptionElement).selected = true
 

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -1,5 +1,6 @@
 /* tslint:disable max-classes-per-file */
 import { JSDOM } from "jsdom"
+import { JSX } from "../src/purview"
 
 const { document } = new JSDOM().window
 Object.assign(global, { document })
@@ -17,7 +18,6 @@ import Purview, {
   css,
   RENDER_CSS_ORDERING_ERROR,
   styledTag,
-  reloadOptions,
   pingClients,
 } from "../src/purview"
 import { parseHTML, concretize, STYLE_TAG_ID } from "../src/helpers"
@@ -1949,12 +1949,12 @@ test("cleanup happens when 'close' and 'connect' race", async () => {
     // `getStateTree`. To allow jest to clean up the mock implementation, we use
     // `spyOn` and call `spy.mockRestore()` once test execution has completed.
     // This prevent subsequnt tests from using the mock implementation.
-    const spy = jest.spyOn(reloadOptions, "getStateTree")
+    const spy = jest.spyOn(Purview.reloadOptions, "getStateTree")
     spy.mockImplementationOnce(async rootID => {
       // Create an artificial delay when fetching state trees so that the
       // "close" event executes before the "connect" event finishes.
       await new Promise(resolve => setTimeout(resolve, 200))
-      return await reloadOptions.getStateTree(rootID)
+      return await Purview.reloadOptions.getStateTree(rootID)
     })
     const connect: ClientMessage = {
       type: "connect",

--- a/test/purview_test.tsx
+++ b/test/purview_test.tsx
@@ -1,5 +1,4 @@
 /* tslint:disable max-classes-per-file */
-import { JSX } from "../src/purview"
 const mockEventHandlerGracePeriodMS = 150
 jest.mock("../src/constants", () => {
   const constants = jest.requireActual("../src/constants")
@@ -27,6 +26,7 @@ import Purview, {
   RENDER_CSS_ORDERING_ERROR,
   styledTag,
   pingClients,
+  JSX,
 } from "../src/purview"
 import { parseHTML, concretize, STYLE_TAG_ID } from "../src/helpers"
 import {

--- a/test/to_html_test.tsx
+++ b/test/to_html_test.tsx
@@ -1,4 +1,4 @@
-import Purview from "../src/purview"
+import Purview, { JSX } from "../src/purview"
 import { toHTML } from "../src/to_html"
 import { virtualize } from "../src/helpers"
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,10 @@ const config = {
   output: {
     filename: "[name].js",
     path: pathLib.resolve(__dirname, "build"),
+    // Set the hashFunction to "xxhash64" to combat a 
+    // compatibility/vulnerability issue that was causing 
+    // the build to error.  
+    // Please see: https://stackoverflow.com/a/73027407
     hashFunction: "xxhash64",
   },
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,9 +25,8 @@ const config = {
   output: {
     filename: "[name].js",
     path: pathLib.resolve(__dirname, "build"),
-    // Set the hashFunction to "xxhash64" to combat a 
-    // compatibility/vulnerability issue that was causing 
-    // the build to error.  
+    // Set the hashFunction to "xxhash64" to combat a compatibility/
+    // vulnerability issue that was causing the build to error.  
     // Please see: https://stackoverflow.com/a/73027407
     hashFunction: "xxhash64",
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ const config = {
   output: {
     filename: "[name].js",
     path: pathLib.resolve(__dirname, "build"),
+    hashFunction: "xxhash64",
   },
 }
 


### PR DESCRIPTION
With the introduction of React into Orum, incompatible global JSX namespaces became a concern. Initially, we sought to keep the type environments for `react-orum` and the rest of Orum independent, however with the introduction of tRPC to support network requests, the cost of split type environments became too great. The changes in this PR adjust Purview's JSX namespace declaration to conform to TypeScript's [locally-scoped JSX namespaces](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#locally-scoped-jsx-namespaces), enabling Purview to appear in codebases alongside React or any other JSX rendering framework.

[tRPC](https://trpc.io/) is a desirable technology due to its flexibility and developer workflow. API calls are automatically type-checked in terms of the inputs and outputs expressed using tRPC's API, including optional validation via Zod or other validation utility. In the near term, RPC creation will be simple and straightforward; In the long run, tRPC can support graphQL queries (via the underlying `react-query`) as well as [REST API design with OpenAPI support](https://github.com/jlalmes/trpc-openapi). It appears to have a [thriving open-source community](https://trpc.io/docs/community/awesome-trpc) surrounding its development. tRPC is also an exciting technology for several members of Orum's engineering department. 

Using tRPC in its usual form mandates a mono-repo and a shared type environment between frontend and backend. Orum is a mono-repo, so in principle tRPC is ideal for our use case.  Sharing a type environment can have its advantages and disadvantages, but in my opinion, no conflict is likely to be as tricky as the current JSX issue in future, and effortlessly reusing types (ie. no code generation) has obvious upside. API types defined within Orum can also be easily shared with the websocket implementation, a key consideration when compared with the code generation-reliant solutions discussed below. 

Alternatives considered included GraphQL, manual typing, as well as GRPC:

_GraphQL:_
1. Great Developer workflow and tooling 
2. Essentially universal API
3. Ultimately, defining the GraphQL API alongside a non-GraphQL websocket communication later felt overly complicated.
4. Requires a build step

_Manual typing of the API using Zod in a shared folder:_
1. Simple and technology-independent
2. More boilerplate, arguably a more significant learning curve and more cumbersome workflow: anyone who wants to add or adjust a route and consume it will need to make sure they add/adjust the right types in the shared folder and import them properly to the frontend and backend respectively. 
3. Doesn't seem to promote the right separation of concerns; in the long run, it feels like the API should own its own interface, not import it from a shared location. tRPC lets us locate our API type definitions adjacent to the handlers themselves. 

_GRPC:_
1. Like GraphQL, essentially universal API
2. Already exists inside of Orum
3. Using https://github.com/connectrpc/connect-query-es, it seems like decent React client-side support is possible
4. Connect-Query doesn't look as mature as tRPC
5. Requires a build step

Ultimately tRPC offers us the greatest bang for our buck right away, while promising a modern, well-maintained technology going forward. If Orum ever creates a mobile app or needs to create a publicly consumable API, it is possible this choice will need to be reconsidered at that time. tRPC however would not prohibit us from such steps; it just may not be as ideal as GraphQL or GRPC for those purposes. Again note that tRPC relies on react-query, which does itself [support graphQL](https://tanstack.com/query/v4/docs/react/graphql), and that tRPC supports OpenAPI if we ever wanted to go the REST API route.

Finally, even if tRPC were not the proximate cause for this change to Purview, this change is independently good for the open-source project since it improves interoperability with other JSX-based frameworks. 

**Note** that this is a **breaking change.** Existing codebases using Purview that reference the JSX namespace without directly importing it will no longer compile. This can be easily fixed by importing the namespace eg. `import Purview, { JSX, ... } from "purview"`. Additionally, `import * as Purview` no longer behaves as expected, and `import Purview` is required in most cases. Additionally, `import * as Purview` no longer behaves as expected, and `import Purview` is required in most cases.