### PR TITLE
Raise WS_PONG_TIMEOUT from 5s to 15s

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -128,7 +128,7 @@ export const CAPTURE_TEXT = "Capture"
 export const STYLE_TAG_ID = "purview-css"
 
 export const WS_PING_INTERVAL = 2_000 // ms
-export const WS_PONG_TIMEOUT = 5_000 // ms
+export const WS_PONG_TIMEOUT = 15_000 // ms
 
 export function isEventAttr(attr: string): attr is EventAttribute {
   return EVENT_ATTRS.has(attr)


### PR DESCRIPTION
This is a bit of an experiment to see what might happen if we wait longer before closing terminating the ws connection for clients experiencing poor network conditions.

I am not expecting any adverse effects on Purview users due to this change.